### PR TITLE
Additional cleanup and improvements

### DIFF
--- a/data/languages/fr60.ldefs
+++ b/data/languages/fr60.ldefs
@@ -7,7 +7,7 @@
             endian="big"
             size="32"
             variant="default"
-            version="1.0"
+            version="1.1"
             slafile="fr60.sla"
             processorspec="fr60.pspec"
             id="fr60:BE:16:default">

--- a/data/languages/fr60.sinc
+++ b/data/languages/fr60.sinc
@@ -287,22 +287,22 @@ ldm0_list: R0,ldm_r1   is R0 & ldm_r1 & ldmrlist0=1                { R0 = *[ram]
 ldm0_list: ldm_r1      is ldm_r1                                   {                                 build ldm_r1; }
 
 
-CC: "RA" is cc=0x0 { local tmp:1 = 1; export *[const]:1 tmp; }
-CC: "NO" is cc=0x1 { local tmp:1 = 0; export *[const]:1 tmp; }
-CC: "EQ" is cc=0x2 { local tmp:1 = (Z == 1); export *[const]:1 tmp; }
-CC: "NE" is cc=0x3 { local tmp:1 = (Z == 0); export *[const]:1 tmp; }
-CC: "C"  is cc=0x4 { local tmp:1 = (C == 1); export *[const]:1 tmp; }
-CC: "NC" is cc=0x5 { local tmp:1 = (C == 0); export *[const]:1 tmp; }
-CC: "N"  is cc=0x6 { local tmp:1 = (N == 1); export *[const]:1 tmp; }
-CC: "P"  is cc=0x7 { local tmp:1 = (N == 0); export *[const]:1 tmp; }
-CC: "V"  is cc=0x8 { local tmp:1 = (V == 1); export *[const]:1 tmp; }
-CC: "NV" is cc=0x9 { local tmp:1 = (V == 0); export *[const]:1 tmp; }
-CC: "LT" is cc=0xA { local tmp:1 = ((V ^ N) == 1); export *[const]:1 tmp; }
-CC: "GE" is cc=0xB { local tmp:1 = ((V ^ N) == 0); export *[const]:1 tmp; }
-CC: "LE" is cc=0xC { local tmp:1 = (((V ^ N) | Z) == 1); export *[const]:1 tmp; }
-CC: "GT" is cc=0xD { local tmp:1 = (((V ^ N) | Z) == 0); export *[const]:1 tmp; }
-CC: "LS" is cc=0xE { local tmp:1 = ((C | Z) == 1); export *[const]:1 tmp; }
-CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
+CC: "RA" is cc=0x0 { local tmp:1 = 1; export tmp; }
+CC: "NO" is cc=0x1 { local tmp:1 = 0; export tmp; }
+CC: "EQ" is cc=0x2 { local tmp:1 = (Z == 1); export tmp; }
+CC: "NE" is cc=0x3 { local tmp:1 = (Z == 0); export tmp; }
+CC: "C"  is cc=0x4 { local tmp:1 = (C == 1); export tmp; }
+CC: "NC" is cc=0x5 { local tmp:1 = (C == 0); export tmp; }
+CC: "N"  is cc=0x6 { local tmp:1 = (N == 1); export tmp; }
+CC: "P"  is cc=0x7 { local tmp:1 = (N == 0); export tmp; }
+CC: "V"  is cc=0x8 { local tmp:1 = (V == 1); export tmp; }
+CC: "NV" is cc=0x9 { local tmp:1 = (V == 0); export tmp; }
+CC: "LT" is cc=0xA { local tmp:1 = ((V ^ N) == 1); export tmp; }
+CC: "GE" is cc=0xB { local tmp:1 = ((V ^ N) == 0); export tmp; }
+CC: "LE" is cc=0xC { local tmp:1 = (((V ^ N) | Z) == 1); export tmp; }
+CC: "GT" is cc=0xD { local tmp:1 = (((V ^ N) | Z) == 0); export tmp; }
+CC: "LS" is cc=0xE { local tmp:1 = ((C | Z) == 1); export tmp; }
+CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export tmp; }
 
 
 # ====

--- a/data/languages/fr60.sinc
+++ b/data/languages/fr60.sinc
@@ -3,14 +3,17 @@ define token instr (16)
     op16     = (0,15)
     op12     = (4,15)
     op8      = (8,15)
+    op7      = (9,15)
     op5      = (11,15)
     op4      = (12,15)
 
     cc       = (8,11)
     i8       = (4,11)
     o8       = (4,11) signed
+    u5       = (4,8)
+    s5       = (4,8) signed
     u4       = (4,7)
-    i4       = (4,7)
+    i4       = (4,7) signed
     rj       = (4,7)
     rs4_4    = (4,7)
 
@@ -50,33 +53,22 @@ define token instr (16)
     ldmrlist6N = (6,7)
     ldmrlist7N = (7,7)
 
+    ccu4     = (0,3)
     ri       = (0,3)
     rs       = (0,3)
-;
-
-define token instr48 (48)
-    op48_12  = (36,47)
-    ri48_4   = (32,35)
-    i32      = (0,31)
+    i16      = (0,15)
+    cri      = (0,3)
+    crj      = (4,7)
+    copcc    = (9,15)
 ;
 
 define token instr32 (32)
-    op32_8   = (24,31)
-    i20_4h   = (20,23)
-    ri32_4   = (16,19)
-    i20_16l  = (0,15)
-
-    op32_12  = (20,31)
-    u32_4    = (16,19)
-    cc32_6   = (10,15)
-    cc32_2   = (8,9)
-    crj32_4  = (4,7)
-    cri32_4  = (0,3)
+    i32      = (0,31)
 ;
 
-attach variables [ ri rj ri48_4 ri32_4 ] [ R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 AC FP SP ];
-attach variables [ rs rs4_4 ] [ TBR RP SSP USP MDH MDL _ _ _ _ _ _ _ _ _ _ ];
-attach names [ cc32_2 ] [ ADD SUB MUL DIV ];
+attach variables [ ri rj ] [ R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 AC FP SP ];
+
+attach variables [ rs ] [ TBR RP SSP USP MDH MDL _ _ _ _ _ _ _ _ _ _ ];
 
 # ====
 
@@ -127,24 +119,12 @@ define pcodeop _interrupt_prelude;
 define pcodeop dma_write_chan;
 define pcodeop dma_read_chan;
 
+define pcodeop copop;
+define pcodeop copld;
+define pcodeop copst;
+define pcodeop copsv;
+
 # ====
-
-# 4 bit immediates don't convert cleanly with zext/sext unless they are 1 byte in size
-signedi_4: i4 is i4 {
-    local res:4 = 0;
-    # if 4bit number is neg
-    if (0b00001000 & i4:1) goto <NEG>;
-    res = zext(i4:1);
-<NEG>
-    res = sext(i4:1 | 0xF0);
-
-    export res;
-}
-
-usignedi_4: i4 is i4 {
-    local ext:4 = zext(i4:1);
-    export ext;
-}
 
 bandl_ext: u4 is u4 {
     local value:1 = 0xf0 | u4;
@@ -156,24 +136,19 @@ bandh_ext: u4 is u4 {
     export value;
 }
 
-REL: reloc is rel8 [ reloc = inst_next + (rel8 * 2); ] {
+REL: reloc is rel8 [ reloc = inst_next + (rel8 << 1); ] {
     export *:2 reloc;
 }
 
-REL_SEXT11: reloc is rel11 [ reloc = inst_next + (rel11 * 2); ] {
+REL_SEXT11: reloc is rel11 [ reloc = inst_next + (rel11 << 1); ] {
     export *:2 reloc;
 }
 
-LDI_20_CON: comb is i20_4h & i20_16l [ comb = (i20_4h << 16) + i20_16l; ] {
-    local result:4 = zext(comb:3);
-    export result;
-}
-
-DIR8_REL: reloc is dir8 [ reloc = dir8 * 4; ] {
+DIR8_REL: reloc is dir8 [ reloc = dir8 << 2; ] {
     export *:4 reloc;
 }
 
-DIR8H_REL: reloc is dir8 [ reloc = dir8 * 2; ] {
+DIR8H_REL: reloc is dir8 [ reloc = dir8 << 1; ] {
     export *:2 reloc;
 }
 
@@ -332,189 +307,248 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# ADD Rj, Ri A A6 1 CCCC Ri + Rj --> Ri
 :ADD rj, ri is op8=0xa6 & rj & ri {
     local res:4 = ri + rj;
     addFlags(res, ri, rj);
     ri = res;
 }
 
-:ADD #usignedi_4, ri is op8=0xa4 & usignedi_4 & ri {
-    local res:4 = ri + usignedi_4;
-    addFlags(res, ri, usignedi_4);
+# ADD #s5, Ri C’ A4 1 CCCC Ri + s5 --> Ri
+:ADD #s5, ri is op7=0x52 & s5 & ri {
+	local res:4 = ri + s5;
+	addFlags(res, ri, s5);
+	ri = res;
+}
+
+# ADD #u4, Ri C A4 1 CCCC Ri + extu(i4) --> Ri (zero extension)
+:ADD #u4, ri is op8=0xa4 & u4 & ri {
+    local res:4 = ri + u4;
+    addFlags(res, ri, u4);
     ri = res;
 }
 
-:ADD2 #signedi_4, ri is op8=0xa5 & signedi_4 & ri {
-    local res:4 = ri + signedi_4;
-    addFlags(res, ri, signedi_4);
+# ADD2 #u4, Ri C A5 1 CCCC Ri + extu(i4) --> Ri  (minus extension)
+:ADD2 #i4, ri is op8=0xa5 & i4 & ri {
+    local res:4 = ri + i4;
+    addFlags(res, ri, i4);
     ri = res;
 }
 
+# ADDC Rj, Ri A A7 1 CCCC Ri + Rj + c --> Ri (addition with carry)
 :ADDC rj, ri is op8=0xa7 & rj & ri {
     local res:4 = ri + rj + zext(C:1);
     addFlags(res, ri, (rj + zext(C:1)));
     ri = res;
 }
 
+# ADDN Rj, Ri A A2 1 ---- Ri + Rj --> Ri
 :ADDN rj, ri is op8=0xa2 & rj & ri {
     ri = ri + rj;
 }
 
-:ADDN #usignedi_4, ri is op8=0xa0 & usignedi_4 & ri {
-    ri = ri + usignedi_4;
+# ADDN #s5, Ri C’ A0 1 ---- Ri + s5 --> Ri
+:ADDN #s5, ri is op7=0x50 & s5 & ri {
+    ri = s5 + ri;
 }
 
-:ADDN2 #signedi_4, ri is op8=0xa1 & signedi_4 & ri {
-    ri = ri + signedi_4;
+# ADDN #u4, Ri C A0 1 ---- Ri + extu(i4) --> Ri (zero extension)
+:ADDN #u4, ri is op8=0xa0 & u4 & ri {
+    ri = ri + u4;
+}
+
+# ADDN2 #u4, Ri C A1 1 ---- Ri + extu(i4) --> Ri (minux extension)
+:ADDN2 #i4, ri is op8=0xa1 & i4 & ri {
+    ri = ri + i4;
 }
 
 # ====
 
+# SUB Rj, Ri A AC 1 CCCC Ri - Rj --> Ri
 :SUB rj, ri is op8=0xac & rj & ri {
     local res:4 = ri - rj;
     subFlags(res, ri, rj);
     ri = res;
 }
 
+# SUBC Rj, Ri A AD 1 CCCC Ri - Rj - c --> Ri (addition with carry)
 :SUBC rj, ri is op8=0xad & rj & ri {
     local res:4 = ri - rj - zext(C);
     subFlags(res, ri, (rj - zext(C)));
     ri = res;
 }
 
+# SUBN Rj, Ri A AE 1 ---- Ri - Rj --> Ri
 :SUBN rj, ri is op8=0xae & rj & ri {
     ri = ri - rj;
 }
 
 # ====
 
+# CMP Rj, Ri A AA 1 CCCC Ri - R
 :CMP rj, ri is op8=0xaa & rj & ri {
     local res:4 = ri - rj;
     subFlags(res, ri, rj);
 }
 
-:CMP usignedi_4, ri is op8=0xa8 & usignedi_4 & ri {
-    local res:4 = ri - usignedi_4;
-    subFlags(res, ri, usignedi_4);
+# CMP #s5, Ri C’ A8 1 CCCC Ri - s5
+:CMP #s5, ri is op7=0x54 & s5 & ri {
+    local res:4 = ri - s5;
+    subFlags(res, ri, s5);
 }
 
-:CMP2 signedi_4, ri is op8=0xa9 & signedi_4 & ri {
-    res:4 = ri - signedi_4;
-    subFlags(res, ri, signedi_4);
+# CMP #u4, Ri C A8 1 CCCC Ri - extu(i4) (zero extension)
+:CMP #u4, ri is op8=0xa8 & u4 & ri {
+    local res:4 = ri - u4;
+    subFlags(res, ri, u4);
+}
+
+# CMP2 #u4, Ri C A9 1 CCCC Ri - extu(i4) Minus extension
+:CMP2 #i4, ri is op8=0xa9 & i4 & ri {
+    res:4 = ri - i4;
+    subFlags(res, ri, i4);
 }
 
 # ====
 
+# AND Rj, Ri A 82 1 CC-- Ri &= Rj  Word
 :AND rj, ri is op8=0x82 & rj & ri {
     ri = ri & rj;
     resultFlags(ri);
 }
 
+# AND Rj, @Ri A 84 1+2a CC-- (Ri) &= Rj  Word
 :AND rj, @ri is op8=0x84 & rj & ri {
-    *:4 ri = *:4 ri & rj;
-    resultFlags(*:4 ri);
+    local res:4 = *:4 ri & rj;
+    resultFlags(res);
+    *:4 ri = res;
 }
 
+# ANDH Rj, @Ri A 85 1+2a CC-- (Ri) &= Rj  Halfword
 :ANDH rj, @ri is op8=0x85 & rj & ri {
-    *:2 ri = *:2 ri & rj:2;
-    resultFlags(*:2 ri);
+    local res:2 = *:2 ri & rj:2;
+    resultFlags(res);
+    *:2 ri = res;
 }
 
+# ANDB Rj, @Ri A 86 1+2a CC-- (Ri) &= Rj  Byte
 :ANDB rj, @ri is op8=0x86 & rj & ri {
-    *:1 ri = *:1 ri & rj:1;
-    resultFlags(*:1 ri);
+    local res:1 = *:1 ri & rj:1;
+    resultFlags(res);
+    *:1 ri = res;
 }
 
 # ====
 
+# OR Rj, Ri A 92 1 CC-- Ri | = Rj  Word
 :OR rj, ri is op8=0x92 & rj & ri {
     ri = ri | rj;
     resultFlags(ri);
 }
 
+# OR Rj, @Ri A 94 1+2a CC-- (Ri) | = Rj  Word
 :OR rj, @ri is op8=0x94 & rj & ri {
-    *:4 ri = *:4 ri | rj;
-    resultFlags(*:4 ri);
+    local res:4 = *:4 ri | rj;
+    resultFlags(res);
+    *:4 ri = res;
 }
 
+# ORH Rj, @Ri A 95 1+2a CC-- (Ri) | = Rj  Halfword
 :ORH rj, @ri is op8=0x95 & rj & ri {
-    *:2 ri = *:2 ri | rj:2;
-    resultFlags(*:2 ri);
+    local res:2 = *:2 ri | rj:2;
+    resultFlags(res);
+    *:2 ri = res;
 }
 
+# ORB Rj, @Ri A 96 1+2a CC-- (Ri) | = Rj  Byte
 :ORB rj, @ri is op8=0x96 & rj & ri {
-    *:1 ri = *:1 ri | rj:1;
-    resultFlags(*:1 ri);
+    local res:1 = *:1 ri | rj:1;
+    resultFlags(res);
+    *:1 ri = res;
 }
 
 # ====
 
+# EOR Rj, Ri A 9A 1 CC-- Ri ^ = Rj  Word
 :EOR rj, ri is op8=0x9a & rj & ri {
     ri = ri ^ rj;
     resultFlags(ri);
 }
 
+# EOR Rj, @Ri A 9C 1+2a CC-- (Ri) ^ = Rj  Word
 :EOR rj, @ri is op8=0x9c & rj & ri {
-    *:4 ri = *:4 ri ^ rj;
-    resultFlags(*:4 ri);
+    local res:4 = *:4 ri ^ rj;
+    resultFlags(res);
+    *:4 ri = res;
 }
 
+# EORH Rj, @Ri A 9D 1+2a CC-- (Ri) ^ = Rj  Halfword
 :EORH rj, @ri is op8=0x9d & rj & ri {
-    *:2 ri = *:2 ri ^ rj:2;
-    resultFlags(*:2 ri);
+    local res:2 = *:2 ri ^ rj:2;
+    resultFlags(res);
+    *:2 ri = res;
 }
 
+# EORB Rj, @Ri A 9E 1+2a CC-- (Ri) ^ = Rj  Byte
 :EORB rj, @ri is op8=0x9e & rj & ri {
-    *:1 ri = *:1 ri ^ rj:1;
-    resultFlags(*:1 ri);
+    local res:1 = *:1 ri ^ rj:1;
+    resultFlags(res);
+    *:1 ri = res;
 }
 
 # ====
 
+# BANDL #u4, @Ri C 80 1+2a ---- (Ri)&=(0xF0+u4)
 :BANDL #bandl_ext, @ri is op8=0x80 & bandl_ext & ri {
     *:1 ri = bandl_ext & *:1 ri;
 }
 
+# BANDH #u4, @Ri C 81 1+2a ---- (Ri)&=((u4<<4)+0x0F)
 :BANDH #bandh_ext, @ri is op8=0x81 & bandh_ext & ri {
     *:1 ri = bandh_ext & *:1 ri;
 }
 
 # ====
 
+# BORL #u4, @Ri C 90 1+2a ---- (Ri) | = u4
 :BORL #u4, @ri is op8=0x90 & u4 & ri {
     *:1 ri = u4:1 | *:1 ri;
 }
 
+# BORLH #u4, @Ri C 91 1+2a ---- (Ri) | = (u4<<4)
 :BORH #u4, @ri is op8=0x91 & u4 & ri {
     *:1 ri = (u4:1 << 4) | *:1 ri;
 }
 
 # ====
 
+# BEORL #u4, @Ri C 98 1+2a ---- (Ri) ^ = u4
 :BEORL #u4, @ri is op8=0x98 & u4 & ri {
     *:1 ri = u4:1 ^ *:1 ri;
 }
 
+# BEORH #u4, @Ri C 99 1+2a ---- (Ri) ^ = (u4<<4)
 :BEORH #u4, @ri is op8=0x99 & u4 & ri {
     *:1 ri = (u4:1 << 4) ^ *:1 ri;
 }
 
 # ====
 
+# BTSTL #u4, @Ri C 88 2+a 0C-- (Ri) & u4
 :BTSTL #u4, @ri is op8=0x88 & u4 & ri {
     local res:1 = u4:1 & *:1 ri;
-    # lower 4 bits stored directly to CCR regs
     resultFlags(res);
 }
 
+# BTSTH #u4, @Ri C 89 2+a CC-- (Ri) & (u4<<4)
 :BTSTH #u4, @ri is op8=0x89 & u4 & ri {
     local res:1 = (u4:1 << 4) & *:1 ri;
-    # upper 4 bits stored directly to CCR regs
     resultFlags(res);
 }
 
 # ====
 
+# MUL Rj,Ri A AF 5 CCC- Ri x Rj --> MDH,MDL
 :MUL rj, ri is op8=0xaf & rj & ri {
     local full:8 = sext(rj) * sext(ri);
     MDL = full:4;
@@ -522,6 +556,7 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     mulFlags64(rj, ri);
 }
 
+# MULU Rj,Ri A AB 5 CCC- Ri x Rj --> MDH,MDL
 :MULU rj, ri is op8=0xab & rj & ri {
     local full:8 = zext(rj) * zext(ri);
     MDL = full:4;
@@ -529,11 +564,13 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     mulFlags64(rj, ri);
 }
 
+# MULH Rj,Ri A BF 3 CC-- Ri x Rj --> MDL
 :MULH rj, ri is op8=0xbf & rj & ri {
     MDL = sext(rj:2) * sext(ri:2);
     resultFlags(MDL);
 }
 
+# MULUH Rj,Ri A BB 3 CC-- Ri x Rj --> MDL
 :MULUH rj, ri is op8=0xbb & rj & ri {
     MDL = zext(rj:2) * zext(ri:2);
     resultFlags(MDL);
@@ -541,6 +578,7 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# DIV0S Ri E 97-4 1 ---- Step operation
 :DIV0S ri is op12=0x974 & ri {
     D0 = MDL s< 0;
     D1 = D0 && (ri s< 0);
@@ -549,12 +587,14 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     MDH = ext64(4);
 }
 
+# DIV0U Ri E 97-5 1 ---- 32bits/32bits=32bits
 :DIV0U ri is op12=0x975 & ri {
     D0 = 0;
     D1 = 0;
     MDH = 0x00000000;
 }
 
+# DIV1 Ri E 97-6 d -C-C
 :DIV1 ri is op12=0x976 & ri {
     MD = MD << 1;
 
@@ -576,6 +616,7 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     $(Z_flag) = MDH == 0;
 }
 
+# DIV2 Ri E 97-7 1 -C-C
 :DIV2 ri is op12=0x977 & ri {
     if (D1 == 0) goto <D1_ZERO_OP2>;
         C = carry(MDH, ri);
@@ -592,12 +633,14 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     Z = MDH == 0;
 }
 
+# DIV3 E 9F-6 1 ----
 :DIV3 is op16=0x9f60 & ri {
     if (Z != 1) goto <END>;
         MDL = MDL + 0x1;
     <END>
 }
 
+# DIV4S E 9F-7 1 ----
 :DIV4S is op16=0x9f70 & ri {
     if (D1 != 1) goto <END>;
         MDL = 0 - MDL;
@@ -606,118 +649,155 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# LSL Rj, Ri A B6 1 CC-C Ri << Rj --> Ri
 :LSL rj, ri is op8=0xb6 & rj & ri {
     local shiftAmount = rj & 0x1f;
-    ri = ri << shiftAmount;
-
     C = ((ri << shiftAmount -1) & 0x80000000) != 0;
+    ri = ri << shiftAmount;
     resultFlags(ri);
 }
 
-:LSL #usignedi_4, ri is op8=0xb4 & usignedi_4 & ri {
-    local shiftAmount = usignedi_4;
-    ri = ri << shiftAmount;
-
+# LSL #u5, Ri (u5:0 to 31) C' B4 1 CC-C Ri << u5 --> Ri
+:LSL #u5, ri is op7=0x5A & u5 & ri {
+    local shiftAmount = u5;
     C = ((ri << shiftAmount -1) & 0x80000000) != 0;
+    ri = ri << shiftAmount;
     resultFlags(ri);
 }
 
-:LSL2 #i4_imm, ri is op8=0xb5 & i4 & ri [ i4_imm = i4 + 16; ] {
-    ri = ri << i4_imm;
-    C = ((ri << i4_imm -1) & 0x80000000) != 0;
+# LSL #u4, Ri C B4 1 CC-C Ri << u4 --> Ri
+:LSL #u4, ri is op8=0xb4 & u4 & ri {
+    local shiftAmount = u4;
+    C = ((ri << shiftAmount -1) & 0x80000000) != 0;
+    ri = ri << shiftAmount;
+    resultFlags(ri);
+}
+
+# LSL2 #u4, Ri C B5 1 CC-C Ri <<(u4+16) --> Ri
+:LSL2 #u4_imm, ri is op8=0xb5 & u4 & ri [ u4_imm = u4 + 16; ] {
+    C = ((ri << u4_imm -1) & 0x80000000) != 0;
+    ri = ri << u4_imm;
     resultFlags(ri);
 }
 
 # ====
 
+# LSR Rj, Ri A B2 1 CC-C Ri >> Rj --> Ri
 :LSR rj, ri is op8=0xb2 & rj & ri {
     local shiftAmount = rj & 0x1f;
-    ri = ri >> shiftAmount;
-
     C = ((ri >> shiftAmount -1) & 0x1) != 0;
+    ri = ri >> shiftAmount;
     resultFlags(ri);
 }
 
-:LSR #usignedi_4, ri is op8=0xb0 & usignedi_4 & ri {
-    local shiftAmount = usignedi_4;
-    ri = ri >> shiftAmount;
-
+#LSR #u5, Ri (u5:0 to 31) C' B0 1 CC-C Ri >> u5 --> Ri
+:LSR #u5, ri is op7=0x58 & u5 & ri {
+    local shiftAmount = u5;
     C = ((ri >> shiftAmount -1) & 0x1) != 0;
+    ri = ri >> shiftAmount;
     resultFlags(ri);
 }
 
-:LSR2 #i4_imm, ri is op8=0xb1 & i4 & ri [ i4_imm = i4 + 16; ] {
-    ri = ri >> i4_imm;
-    C = ((ri >> i4_imm -1) & 0x1) != 0;
+#LSR #u4, Ri C B0 1 CC-C Ri >> u4 --> Ri
+:LSR #u4, ri is op8=0xb0 & u4 & ri {
+    local shiftAmount = u4;
+    C = ((ri >> shiftAmount -1) & 0x1) != 0;
+    ri = ri >> shiftAmount;
+    resultFlags(ri);
+}
+
+#LSR2 #u4, Ri C B1 1 CC-C Ri >>(u4+16) --> Ri
+:LSR2 #u4_imm, ri is op8=0xb1 & u4 & ri [ u4_imm = u4 + 16; ] {
+    C = ((ri >> u4_imm -1) & 0x1) != 0;
+    ri = ri >> u4_imm;
     resultFlags(ri);
 }
 
 # ====
 
+#ASR Rj, Ri A BA 1 CC-C Ri >> Rj --> Ri
 :ASR rj, ri is op8=0xba & rj & ri {
     local shiftAmount = rj & 0x1f;
-    ri = ri s>> shiftAmount;
-
     C = ((ri s>> shiftAmount -1) & 0x1) != 0;
+    ri = ri s>> shiftAmount;
     resultFlags(ri);
 }
 
-:ASR #usignedi_4, ri is op8=0xb8 & usignedi_4 & ri {
-    local shiftAmount = usignedi_4;
-    ri = ri s>> shiftAmount;
-
+#ASR #u5, Ri (u5:0 to 31) C' B8 1 CC-C Ri >> u5 --> Ri
+:ASR #u5, ri is op7=0x5C & u5 & ri {
+    local shiftAmount = u5;
     C = ((ri s>> shiftAmount -1) & 0x1) != 0;
+    ri = ri s>> shiftAmount;
     resultFlags(ri);
 }
 
-:ASR2 #i4_imm, ri is op8=0xb9 & i4 & ri [ i4_imm = i4 + 16; ] {
-    ri = ri >> i4_imm;
-    C = ((ri >> i4_imm -1) & 0x1) != 0;
+#ASR #u4, Ri C B8 1 CC-C Ri >> u4 --> Ri
+:ASR #u4, ri is op8=0xb8 & u4 & ri {
+    local shiftAmount = u4;
+    C = ((ri s>> shiftAmount -1) & 0x1) != 0;
+    ri = ri s>> shiftAmount;
+    resultFlags(ri);
+}
+
+#ASR2 #u4, Ri C B9 1 CC-C Ri >>(u4+16) --> Ri
+:ASR2 #u4_imm, ri is op8=0xb9 & u4 & ri [ u4_imm = u4 + 16; ] {
+    C = ((ri >> u4_imm -1) & 0x1) != 0;
+    ri = ri >> u4_imm;
     resultFlags(ri);
 }
 
 # ====
 
-:LDI^":32" #i32, ri48_4 is op48_12=0x9f8 & i32 & ri48_4 {
-    ri48_4 = i32;
+# LDI:32 #i32, Ri E 9F-8 3 ---- i32 --> Ri
+:LDI^":32" #i32, ri is op12=0x9f8 & ri ; i32 {
+    ri = i32;
 }
 
-:LDI^":20" #LDI_20_CON, ri32_4 is op32_8=0x9b & LDI_20_CON & ri32_4 {
-    ri32_4 = LDI_20_CON;
+# LDI:20 #i20, Ri C 9B 2 ---- i20 --> Ri
+:LDI^":20" #i20, ri is op8=0x9b & ri & u4; i16 [ i20 = (u4 << 16) + i16; ] {
+    ri = i20;
 }
 
+# LDI:8 #i8, Ri B C0 1 ---- i8 --> Ri
 :LDI^":8" #i8, ri is op4=0xc & i8 & ri {
-    ri = zext(i8:1);
+    ri = i8;
 }
 
 # ====
 
+# LD @Rj, Ri A 04 b ---- (Rj) --> Ri
 :LD @rj, ri is op8=0x04 & rj & ri {
     ri = *:4 rj;
 }
 
+# LD @(R13,Rj), Ri A 00 b ---- (R13+Rj) --> Ri
 :LD @(AC, rj), ri is op8=0x00 & rj & ri & AC {
     ri = *:4 (AC + rj);
 }
 
-:LD @(FP, o8_imm), ri is op4=0x2 & o8 & ri & FP [ o8_imm = o8 * 4; ]{
+# LD @(R14,disp10), Ri B 20 b ---- (R14+disp10) --> Ri
+:LD @(FP, o8_imm), ri is op4=0x2 & o8 & ri & FP [ o8_imm = o8 << 2; ]{
     ri = *:4 (FP + o8_imm);
 }
 
-:LD @(SP, i4_imm), ri is op8=0x03 & i4 & ri & SP [ i4_imm = i4 * 4; ] {
-    ri = *:4 (SP + i4_imm);
+# LD @(R15,udisp6), Ri C 03 b ---- (R15+udisp6) --> Ri
+:LD @(SP, u4_imm), ri is op8=0x03 & u4 & ri & SP [ u4_imm = u4 << 2; ] {
+    ri = *:4 (SP + u4_imm);
 }
 
+# LD @R15+, Ri E 07-0 b ---- (R15) --> Ri,R15+=4
 :LD @SP+, ri is op12=0x070 & ri & SP {
     ri = *:4 SP;
     SP = SP + 4;
 }
 
+# LD @R15+, Rs E 07-8 b ---- (R15) --> Rs, R15+=4
 :LD @SP+, rs is op12=0x078 & rs & SP {
     rs = *:4 SP;
     SP = SP + 4;
 }
 
+# LD @R15+, PS E 07-9 1+a+b CCCC (R15) --> PS, R15+=4
 :LD @SP+, PS is op16=0x0790 & SP & PS {
     PS = *:4 SP;
     SP = SP + 4;
@@ -725,60 +805,73 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# LDUH @Rj, Ri A 05 b ---- (Rj) -->Ri Zero extension
 :LDUH @rj, ri is op8=0x05 & rj & ri {
     ri = zext(*:2 rj);
 }
 
+# LDUH @(R13,Rj), Ri A 01 b ---- (R13+Rj) -->Ri Zero extension
 :LDUH @(AC, rj), ri is op8=0x01 & rj & ri & AC {
     ri = zext(*:2 (AC + rj));
 }
 
-:LDUH @(FP, o8_imm), ri is op4=0x4 & o8 & ri & FP [ o8_imm = o8 * 2; ] {
+# LDUH @(R14,disp9), Ri B 40 b ---- (R14+disp9) -->Ri Zero extension
+:LDUH @(FP, o8_imm), ri is op4=0x4 & o8 & ri & FP [ o8_imm = o8 << 1; ] {
     ri = zext(*:2 (FP + o8_imm));
 }
 
 # ====
 
+# LDUB @Rj, Ri A 06 b ---- (Rj) -->Ri Zero extension
 :LDUB @rj, ri is op8=0x06 & rj & ri {
     ri = zext(*:1 rj);
 }
 
+# LDUB @(R13,Rj), Ri A 02 b ---- (R13+Rj) -->Ri Zero extension
 :LDUB @(AC, rj), ri is op8=0x02 & rj & ri & AC {
     ri = zext(*:1 (AC + rj));
 }
 
+# LDUB @(R14,disp8), Ri B 60 b ---- (R14+disp8) -->Ri Zero extension
 :LDUB @(FP, o8), ri is op4=0x6 & o8 & ri & FP {
     ri = zext(*:1 (FP + o8));
 }
 
 # ====
 
+# ST Ri, @Rj A 14 a ---- Ri --> (Rj)
 :ST ri, @rj is op8=0x14 & rj & ri {
     *:4 rj = ri;
 }
 
+# ST Ri, @(R13,Rj) A 10 a ---- Ri --> (R13+Rj)
 :ST ri, @(AC, rj) is op8=0x10 & rj & ri & AC {
     *:4 (AC + rj) = ri;
 }
 
-:ST ri, @(FP, o8_imm) is op4=0x3 & o8 & ri & FP [ o8_imm = o8 * 4; ] {
+# ST Ri, @(R14,disp10) B 30 a ---- Ri --> (R14+disp10)
+:ST ri, @(FP, o8_imm) is op4=0x3 & o8 & ri & FP [ o8_imm = o8 << 2; ] {
     *:4 (FP + o8_imm) = ri;
 }
 
-:ST ri, @(SP, u4_imm) is op8=0x13 & u4 & ri & SP [ u4_imm = u4 * 4; ] {
+# ST Ri, @(R15,udisp6) C 13 a ---- Ri --> (R15+udisp6)
+:ST ri, @(SP, u4_imm) is op8=0x13 & u4 & ri & SP [ u4_imm = u4 << 2; ] {
     *:4 (SP + u4_imm) = ri;
 }
 
+# ST Ri, @-R15 E 17-0 a ---- R15-=4,Ri --> (R15)
 :ST ri @-SP is op12=0x170 & ri & SP {
     SP = SP - 4;
     *:4 SP = ri;
 }
 
+# ST Rs, @-R15 E 17-8 a ---- R15-=4, Rs --> (R15)
 :ST rs @-SP is op12=0x178 & rs & SP {
     SP = SP - 4;
     *:4 SP = rs;
 }
 
+# ST PS, @-R15 E 17-9 a ---- R15-=4, PS --> (R15)
 :ST PS, @-SP is op16=0x1790 & SP & PS {
     SP = SP - 4;
     *:4 SP = PS;
@@ -786,82 +879,126 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# STH Ri, @Rj A 15 a ---- Ri --> (Rj)
 :STH ri, @rj is op8=0x15 & rj & ri {
     *:2 rj = ri:2;
 }
 
+# STH Ri, @(R13,Rj) A 11 a ---- Ri --> (R13+Rj)
 :STH ri, @(AC, rj) is op8=0x11 & rj & ri & AC {
     *:2 (AC + rj) = ri:2;
 }
 
-:STH ri, @(FP, o8imm) is op4=0x5 & o8 & ri & FP [ o8imm = o8 * 2; ] {
+# STH Ri, @(R14,disp9) B 50 a ---- Ri --> (R14+disp9)
+:STH ri, @(FP, o8imm) is op4=0x5 & o8 & ri & FP [ o8imm = o8 << 1; ] {
     *:2 (FP + o8imm) = ri:2;
 }
 
 # ====
 
+# STB Ri, @Rj A 16 a ---- Ri --> (Rj)
 :STB ri, @rj is op8=0x16 & rj & ri {
     *:1 rj = ri:1;
 }
 
+# STB Ri, @(R13,Rj) A 12 a ---- Ri --> (R13+Rj)
 :STB ri, @(AC, rj) is op8=0x12 & rj & ri & AC {
     *:1 (AC + rj) = ri:1;
 }
 
+# STB Ri, @(R14,disp8) B 70 a ---- Ri --> (R14+disp8)
 :STB ri, @(FP, o8) is op4=0x7 & o8 & ri & FP {
     *:1 (FP + o8) = ri:1;
 }
 
 # ====
 
+# MOV Rj, Ri A 8B 1 ---- Rj --> Ri
 :MOV rj, ri is op8=0x8b & rj & ri {
     ri = rj;
 }
 
+# MOV Rs, Ri A B7 1 ---- Rs --> Ri
 :MOV rs4_4, ri is op8=0xb7 & rs4_4 & ri {
     ri = rs4_4;
 }
 
-:MOV PS, ri is op12=0x171 & ri & PS {
-    ri = PS;
-}
-
+# MOV Ri, Rs E B3 1 ---- Ri --> Rs
 :MOV ri, rs4_4 is op8=0xb3 & rs4_4 & ri {
     rs4_4 = ri;
 }
 
+# MOV PS, Ri E 17-1 1 ---- PS --> Ri
+:MOV PS, ri is op12=0x171 & ri & PS {
+    ri = PS;
+}
+
+# MOV Ri, PS E 07-1 c CCCC Ri --> PS
 :MOV ri, PS is op12=0x071 & ri & PS {
     PS = ri;
 }
 
 # ====
 
+# JMP @Ri E 97-0 2 ---- Ri --> PC
 :JMP @ri is op12=0x970 & ri {
     goto [ri];
 }
 
+# JMP:D @Ri E 9F-0 1 ---- Ri --> PC
+:JMP^":D" @ri is op12=0x9f0 & ri {
+    delayslot(1);
+    goto [ri];
+}
+
+# CALL label12 F D0 2 ---- PC+2-->RP , PC+2+(label12-PC-2)-->PC
 :CALL REL_SEXT11 is op5=0x1A & REL_SEXT11 {
     RP = inst_next;
     call REL_SEXT11;
 }
 
+# CALL:D label12 F D8 1 ---- PC+4 --> RP, PC+2+(label12-PC-2) --> PC
+:CALL^":D" REL_SEXT11 is op5=0x1b & REL_SEXT11 {
+    RP = inst_next;
+    delayslot(1);
+    call REL_SEXT11;
+}
+
+# CALL @Ri E 97-1 2 ---- PC+2-->RP ,Ri-->PC
 :CALL @ri is op12=0x971 & ri {
     RP = inst_next;
     call [ri];
 }
 
+# CALL:D @Ri E 9F-1 1 ---- PC+4 --> RP ,Ri --> PC
+:CALL^":D" @ri is op12=0x9f1 & ri {
+    RP = inst_next;
+    delayslot(1);
+    call [ri];
+}
+
+# RET E 97-2 2 ---- RP --> PC
 :RET is op16=0x9720 {
     return [RP];
 }
 
+# RET:D E 9F-2 1 ---- RP --> PC
+:RET^":D" is op16=0x9f20 {
+    delayslot(1);
+    return [RP];
+}
+
+# INT #u8 D AC 3+3a ---- SSP-=4,PS --> (SSP),SSP-=4,PC+2 --> (SSP),(TBR+0x3FC-u8x4) --> PC
 :INT #u8 is op8=0x1f & u8 {
      local ea:4 = inst_next;
     _interrupt_prelude(PS, ea);
-    call [((TBR + 0x3FC) - (sext(u8:2) * 4))];
+    call [((TBR + 0x3FC) - (sext(u8:2) << 2))];
 }
 
+# INTE E 9F-3 3+3a ---- SSP-=4,PS --> (SSP),SSP-=4,PC+2 --> (SSP),(TBR+0x3D8) -->PC
 :INTE is op16=0x9F30 unimpl # Emulator only
 
+# RETI E 97-3 2+2A CCCC (R15) --> PC,R15-=4,(R15) --> PS,R15-=4
 :RETI is op16=0x9730 {
     local tempsp:4 = *:4 SP;
     SP = SP + 4;
@@ -873,6 +1010,22 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# BRA label9 D E0 2 ---- PC+2+(label9-PC-2) -->PC
+# BNO label9 D E1 1 ---- No branch
+# BEQ label9 D E2 2/1 ---- if(Z==1) then PC+2+(label9-PC-2) -->PC
+# BNE label9 D E3 2/1 ---- s/Z==0
+# BC label9 D E4 2/1 ---- s/C==1
+# BNC label9 D E5 2/1 ---- s/C==0
+# BN label9 D E6 2/1 ---- s/N==1
+# BP label9 D E7 2/1 ---- s/N==0
+# BV label9 D E8 2/1 ---- s/V==1
+# BNV label9 D E9 2/1 ---- s/V==0
+# BLT label9 D EA 2/1 ---- s/V xor N==1
+# BGE label9 D EB 2/1 ---- s/V xor N==0
+# BLE label9 D EC 2/1 ---- s/(V xor N) or Z==1
+# BGT label9 D ED 2/1 ---- s/(V xor N) or Z==0
+# BLS label9 D EE 2/1 ---- s/C or Z==1
+# BHI label9 D EF 2/1 ---- s/C or Z==0
 :B^CC REL is op4=0xE & CC & REL
 {
     if (CC != 0) goto REL;
@@ -884,53 +1037,37 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     if (CC != 0) goto REL;
 }
 
-:JMP^":D" @ri is op12=0x9f0 & ri {
-    delayslot(1);
-    goto [ri];
-}
-
-:CALL^":D" REL_SEXT11 is op5=0x1b & REL_SEXT11 {
-    RP = inst_next;
-    delayslot(1);
-    call REL_SEXT11;
-}
-
-:CALL^":D" @ri is op12=0x9f1 & ri {
-    RP = inst_next;
-    delayslot(1);
-    call [ri];
-}
-
-:RET^":D" is op16=0x9f20 {
-    delayslot(1);
-    return [RP];
-}
-
 # ====
 
+# DMOV @dir10, R13 D 08 b ---- (dir10) --> R13
 :DMOV @DIR8_REL, AC is op8=0x08 & DIR8_REL & AC {
     AC = DIR8_REL;
 }
 
+# DMOV R13, @dir10 D 18 a ---- R13 --> (dir10)
 :DMOV AC, @DIR8_REL is op8=0x18 & DIR8_REL & AC {
     DIR8_REL = AC;
 }
 
+# DMOV @dir10, @R13+ D 0C 2a ---- (dir10) --> (R13),R13+=4
 :DMOV @DIR8_REL, @AC+ is op8=0x0c & DIR8_REL & AC {
     *:4 AC = DIR8_REL;
     AC = AC + 4;
 }
 
+# DMOV @R13+, @dir10 D 1C 2a ---- (R13) --> (dir10),R13+=4
 :DMOV AC+, @DIR8_REL is op8=0x1c & DIR8_REL & AC {
     DIR8_REL = *:4 AC;
     AC = AC + 4;
 }
 
+# DMOV @dir10, @-R15 D 0B 2a ---- R15-=4,(R15) --> (dir10)
 :DMOV @DIR8_REL, @-SP is op8=0x0b & DIR8_REL & SP {
     SP = SP - 4;
     *:4 SP = DIR8_REL;
 }
 
+# DMOV @R15+, @dir10 D 1B 2a ---- (R15) --> (dir10),R15+=4
 :DMOV @SP+, @DIR8_REL is op8=0x1b & DIR8_REL & SP {
     DIR8_REL = *:4 SP;
     SP = SP + 4;
@@ -938,19 +1075,23 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# DMOVH @dir9, R13 D 09 b ---- (dir9) --> R13
 :DMOVH @DIR8H_REL, AC is op8=0x09 & DIR8H_REL & AC {
     AC = zext(DIR8H_REL);
 }
 
+# DMOVH R13, @dir9 D 19 a ---- R13 --> (dir9)
 :DMOVH AC, @DIR8H_REL is op8=0x19 & DIR8H_REL & AC {
     DIR8H_REL = AC:2;
 }
 
+# DMOVH @dir9, @R13+ D 0D 2a ---- (dir9) --> (R13),R13+=2
 :DMOVH @DIR8H_REL, @AC+ is op8=0x0d & DIR8H_REL & AC {
     *:2 AC = DIR8H_REL;
     AC = AC + 2;
 }
 
+# DMOVH @R13+, @dir9 D 1D 2a ---- (R13) --> (dir9),R13+=2
 :DMOVH @AC+, @DIR8H_REL is op8=0x1d & DIR8H_REL & AC {
     DIR8H_REL = *:2 AC;
     AC = AC + 2;
@@ -958,19 +1099,23 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# DMOVB @dir8, R13 D 0A b ---- (dir8) --> R13
 :DMOVB @DIR8B_REL, AC is op8=0x0a & DIR8B_REL & AC {
     AC = zext(DIR8B_REL);
 }
 
+# DMOVB R13, @dir8 D 1A a ---- R13 --> (dir8)
 :DMOVB AC, @DIR8B_REL is op8=0x1a & DIR8B_REL & AC {
     DIR8B_REL = AC:1;
 }
 
+# DMOVB @dir8, @R13+ D 0E 2a ---- (dir8) --> (R13),R13++
 :DMOVB @DIR8B_REL, @AC+ is op8=0x0e & DIR8B_REL & AC {
     *:1 AC = DIR8B_REL;
     AC = AC + 1;
 }
 
+# DMOVB @R13+, @dir8 D 1E 2a ---- (R13) --> (dir8),R13++
 :DMOVB AC+, @DIR8B_REL is op8=0x1e & DIR8B_REL & AC {
     DIR8B_REL = *:1 AC;
     AC = AC + 1;
@@ -978,29 +1123,70 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
-:LDRES @ri+, #usignedi_4 is op8=0xbc & usignedi_4 & ri {
-    dma_write_chan(usignedi_4, *:4 ri);
+# LDRES @Ri+, #u4 C BC a ---- (Ri) --> u4 resource, Ri+=4
+:LDRES @ri+, #u4 is op8=0xbc & u4 & ri {
+    local tmp:4 = u4;
+    dma_write_chan(tmp, *:4 ri);
     ri = ri + 4;
 }
 
-:STRES #usignedi_4, @ri+ is op8=0xbd & usignedi_4 & ri {
-    dma_read_chan(usignedi_4, *:4 ri);
+# STRES #u4, @Ri+ C BD a ---- u4 resource --> (Ri), Ri+=4
+:STRES #u4, @ri+ is op8=0xbd & u4 & ri {
+    local tmp:4 = u4;
+    *:4 ri = dma_read_chan(tmp);
     ri = ri + 4;
 }
 
 # ====
 
-:COPOP #u32_4, #cc32_2, crj32_4, cri32_4 is op32_12=0x9fc & u32_4 & cc32_6 & cc32_2 & crj32_4 & cri32_4 unimpl
-:COPLD #u32_4, #cc32_2, crj32_4, cri32_4 is op32_12=0x9fd & u32_4 & cc32_6 & cc32_2 & crj32_4 & cri32_4 unimpl
-:COPST #u32_4, #cc32_2, crj32_4, cri32_4 is op32_12=0x9fe & u32_4 & cc32_6 & cc32_2 & crj32_4 & cri32_4 unimpl
-:COPSV #u32_4, #cc32_2, crj32_4, cri32_4 is op32_12=0x9ff & u32_4 & cc32_6 & cc32_2 & crj32_4 & cri32_4 unimpl
+# COPOP #u4, #u8, CRj, CRi E 9F-C 2+a ---- Operation instruction
+:COPOP #ccu4, #copcc, crj, cri is op12=0x9fc & ccu4 ; copcc & crj & cri {
+    local tmp0:4 = ccu4;
+    local tmp1:4 = copcc;
+    local tmp2:4 = crj;
+    local tmp3:4 = cri;
+    copop(tmp0, tmp1, tmp2, tmp3);
+}
+
+# COPLD #u4, #u8, Rj, CRi E 9F-D 1+2a ---- Rj --> CRi
+:COPLD #ccu4, #copcc, rj, cri is op12=0x9fd & ccu4 ; copcc & rj & cri {
+    local tmp0:4 = ccu4;
+    local tmp1:4 = copcc;
+    local tmp2:4 = cri;
+    copld(tmp0, tmp1, rj, tmp2);
+}
+
+# COPST #u4, #u8, CRj, Ri E 9F-E 1+2a ---- CRj --> Ri
+:COPST #ccu4, #copcc, crj, ri is op12=0x9fe & ccu4 ; copcc & crj & ri {
+    local tmp0:4 = ccu4;
+    local tmp1:4 = copcc;
+    local tmp2:4 = crj;
+    ri = copst(tmp0, tmp1, tmp2, ri);
+}
+
+# COPSV #u4, #u8, CRj, Ri E 9F-F 1+2a ---- CRj --> Ri
+:COPSV #ccu4, #copcc, crj, ri is op12=0x9ff & ccu4 & copcc & crj & ri {
+    local tmp0:4 = ccu4;
+    local tmp1:4 = copcc;
+    local tmp2:4 = crj;
+    ri = copsv(tmp0, tmp1, tmp2, ri);
+}
 
 # ====
 
-:NOP is op16=0x9fa0 { }
+# NOP E 9F-A 1 ---- No change
+:NOP is op16=0x9fa0 {
+    # There is no NOP SLEIGH operation
+    # "unimpl" will break disassembly
+    # Empty braces will produce `sleigh` warning
+    # This should get treated as a NOP w/o warnings
+    local tmp_nop:1 = 0;
+    tmp_nop = tmp_nop;
+}
 
 # ====
 
+# ANDCCR #u8 D 83 c CCCC CCR and u8 --> CCR
 :ANDCCR #u8 is op8=0x83 & u8 {
     S = S & ((0b00100000 & u8:1) != 0);
     I = I & ((0b00010000 & u8:1) != 0);
@@ -1010,6 +1196,7 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     C = C & ((0b00000001 & u8:1) != 0);
 }
 
+# ORCCR #u8 D 93 c CCCC CCR or u8 --> CCR
 :ORCCR #u8 is op8=0x93 & u8 {
     S = S | ((0b00100000 & u8:1) != 0);
     I = I | ((0b00010000 & u8:1) != 0);
@@ -1019,62 +1206,72 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
     C = C | ((0b00000001 & u8:1) != 0);
 }
 
+# STILM #u8 D 87 1 ---- i8 --> ILM
 :STILM #u8 is op8=0x87 & u8 {
     ILM = u8:1 & 0x0f;
 }
 
-:ADDSP #s8_imm is op8=0xa3 & s8 [ s8_imm = s8 * 4; ] {
+# ADDSP #s10 D A3 1 ---- R15 += s10
+:ADDSP #s8_imm is op8=0xa3 & s8 [ s8_imm = s8 << 2; ] {
     SP = SP + s8_imm;
 }
 
 # ====
 
+# EXTSB Ri E 97-8 1 ---- Sign extension 8 --> 32bit
 :EXTSB ri is op12=0x978 & ri {
     ri = sext(ri:1);
 }
 
+# EXTUB Ri E 97-9 1 ---- Zero extension 8 --> 32bit
 :EXTUB ri is op12=0x979 & ri {
     ri = zext(ri:1);
 }
 
+# EXTSH Ri E 97-A 1 ---- Sign extension 16 --> 32bit
 :EXTSH ri is op12=0x97a & ri {
     ri = sext(ri:2);
 }
 
+# EXTUH Ri E 97-B 1 ---- Zero extension 16 --> 32bit
 :EXTUH ri is op12=0x97b & ri {
     ri = zext(ri:2);
 }
 
+# LDM0 (reglist) D 8C ---- (R15) --> reglist,R15 increment- Load multi R0-R7
 :LDM0 (ldm0_list) is op8=0x8c & ldm0_list
 {
-	build ldm0_list;
+    build ldm0_list;
 }
 
+# LDM1 (reglist) D 8D ---- (R15) --> reglist,R15 increment- Load multi R8-R15
 :LDM1 (ldm1_list) is op8=0x8d & ldm1_list
 {
-	build ldm1_list;
+    build ldm1_list;
 }
 
+# STM0 (reglist) D 8E ---- R15 decrement,reglist --> (R15)- Store multi R0-R7
 :STM0 (stm0_list) is op8=0x8e & stm0_list
 {
-	build stm0_list;
+    build stm0_list;
 }
 
+# STM1 (reglist) D 8F ---- R15 decrement,reglist --> (R15)- Store multi R8-R15
 :STM1 (stm1_list) is op8=0x8f & stm1_list
 {
-	build stm1_list;
+    build stm1_list;
 }
-
-
 
 # ====
 
-:ENTER #u8_imm is op8=0x0f & u8 [ u8_imm = u8 * 4; ] {
+# ENTER #u10 D 0F 1+a ---- R14 --> (R15 - 4),R15 - 4 --> R14,R15 - u10 --> R15
+:ENTER #u8_imm is op8=0x0f & u8 [ u8_imm = u8 << 2; ] {
     *:4 (SP - 4) = FP;
     FP = SP - 4;
     SP = SP - u8_imm;
 }
 
+# LEAVE E 9F-9 b ---- R14 + 4 --> R15,(R15 - 4) --> R14
 :LEAVE is op16=0x9f90 {
     SP = FP + 4;
     FP = *:4 (SP - 4);
@@ -1082,6 +1279,7 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export *[const]:1 tmp; }
 
 # ====
 
+# XCHB @Rj, Ri*5 A 8A 2a ---- Ri --> TEMP,(Rj) --> Ri,TEMP --> (Rj)
 :XCHB @rj, ri is op8=0x8a & rj & ri {
     local temp:1 = ri:1;
     ri = zext(*:1 rj);

--- a/data/patterns/fr60.xml
+++ b/data/patterns/fr60.xml
@@ -1,0 +1,15 @@
+<patternlist>
+  <patternpairs totalbits="16" postbits="16">
+    <prepatterns>
+      <data> 0x97 0x20 </data> <!-- RET -->
+      <data> 0x9f 0x20 0x.. 0x.. </data> <!-- RET ; delay -->
+    </prepatterns>
+    <postpatterns>
+      <data> 0x17 0x8. 0x0f 0x.. </data> <!-- ST ; ENTER-->
+      <data> 0x8f 0x.. 0x17 0x8. 0x0f 0x.. </data> <!-- STM1 ; ST ; ENTER-->
+      <data> 0x8e 0x.. 0x8f 0x.. 0x17 0x8. 0x0f 0x.. </data> <!-- STM0 ; STM1 ; ST ; ENTER-->
+      <codeboundary />
+      <possiblefuncstart/>
+    </postpatterns>
+  </patternpairs>
+</patternlist>

--- a/data/patterns/patternconstraints.xml
+++ b/data/patterns/patternconstraints.xml
@@ -1,0 +1,5 @@
+<patternconstraints>
+  <language id="fr60:BE:16:default">
+    <patternfile>fr60.xml</patternfile>
+  </language>
+</patternconstraints>


### PR DESCRIPTION
* Added comments to each instruction
* Cleaned up coprocessor instructions
* Included instructions found in MB91301
* usignedi_4 and signedi_4 can be handled with "signed" tokens
* shifted bits instead of multiply
* Cleaned up +16 bit instructions
* Carry flag was calculated from register with operation applied twice
* show store from pcodeop stres

Bumps ldef version due to instruction decoding changes