### PR TITLE
Fix build against 10.4

### DIFF
--- a/src/main/help/help/topics/fr60/help.html
+++ b/src/main/help/help/topics/fr60/help.html
@@ -10,7 +10,7 @@
     <META name="ProgId" content="FrontPage.Editor.Document">
 
     <TITLE>Skeleton Help File for a Module</TITLE>
-    <LINK rel="stylesheet" type="text/css" href="../../shared/Frontpage.css">
+    <LINK rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
   </HEAD>
 
   <BODY>


### PR DESCRIPTION
```
> Task :buildHelp FAILED
Exception in thread "main" ghidra.util.exception.AssertException: Errors parsing HTML file: help.html
Incorrect stylesheet defined - none match help/shared/DefaultStyle.css in file /Users/integer/src/github/ghidra-fr60/src/main/help/help/topics/fr60/help.html
        Discovered stylesheets: [/Users/integer/src/github/ghidra-fr60/src/main/help/help/shared/DefaultStyle.css]
```

see https://github.com/NationalSecurityAgency/ghidra/issues/5328