### PR TITLE
FR-81

### DIFF
--- a/data/languages/fr60.cspec
+++ b/data/languages/fr60.cspec
@@ -30,16 +30,16 @@
   <default_proto>
     <prototype name="fcc911" extrapop="0" stackshift="0" strategy="register">
       <input killedbycall="true">
-        <pentry minsize="1" maxsize="4">
+        <pentry minsize="1" maxsize="4" extension="inttype">
           <register name="R4"/>
         </pentry>
-        <pentry minsize="1" maxsize="4">
+        <pentry minsize="1" maxsize="4" extension="inttype">
           <register name="R5"/>
         </pentry>
-        <pentry minsize="1" maxsize="4">
+        <pentry minsize="1" maxsize="4" extension="inttype">
           <register name="R6"/>
         </pentry>
-        <pentry minsize="1" maxsize="4">
+        <pentry minsize="1" maxsize="4" extension="inttype">
           <register name="R7"/>
         </pentry>
         <pentry minsize="1" maxsize="500" align="4">
@@ -47,7 +47,7 @@
         </pentry>
       </input>
       <output>
-        <pentry minsize="1" maxsize="4">
+        <pentry minsize="1" maxsize="4" extension="inttype">
           <register name="R4"/>
         </pentry>
         <pentry minsize="5" maxsize="8">

--- a/data/languages/fr60.ldefs
+++ b/data/languages/fr60.ldefs
@@ -3,7 +3,7 @@
 <!-- See Relax specification: Ghidra/Framework/SoftwareModeling/data/languages/language_definitions.rxg -->
 
 <language_definitions>
-   <language processor="FR60"
+  <language processor="FR60"
             endian="big"
             size="32"
             variant="default"
@@ -11,6 +11,20 @@
             slafile="fr60.sla"
             processorspec="fr60.pspec"
             id="fr60:BE:16:default">
+   <description>Fujitsu FR 60 Instruction Set</description>
+   <compiler name="fcc911" spec="fr60.cspec" id="fcc911"/>
+   <external_name tool="gnu" name="fr30"/>
+   <external_name tool="DWARF.register.mapping.file" name="fr60.dwarf"/>
+  </language>
+
+  <language processor="FR81"
+            endian="big"
+            size="32"
+            variant="default"
+            version="1.1"
+            slafile="fr81.sla"
+            processorspec="fr60.pspec"
+            id="fr81:BE:16:default">
    <description>Fujitsu FR 60 Instruction Set</description>
    <compiler name="fcc911" spec="fr60.cspec" id="fcc911"/>
    <external_name tool="gnu" name="fr30"/>

--- a/data/languages/fr60.sinc
+++ b/data/languages/fr60.sinc
@@ -1,6 +1,7 @@
 
 define token instr (16)
     op16     = (0,15)
+    op14     = (2,15)
     op12     = (4,15)
     op8      = (8,15)
     op7      = (9,15)
@@ -22,8 +23,6 @@ define token instr (16)
     s8       = (0,7) signed
     rel8     = (0,7) signed
     dir8     = (0,7)
-    rel20hi  = (0,3) signed
-    rel20lo  = (0,15)
 
     stmrlist7 = (0,0)
     stmrlist6 = (1,1)
@@ -63,6 +62,20 @@ define token instr (16)
     cri      = (0,3)
     crj      = (4,7)
     copcc    = (9,15)
+
+@ifdef FR81_EXTENSION
+    fri      = (0,3)
+    frj      = (4,7)
+    frk      = (8,11)
+
+    fcc      = (0,3)
+
+    rel20hi  = (0,3) signed
+    rel20lo  = (0,15)
+    o14shi   = (0,2) signed
+    o14uhi   = (0,2) signed
+    o14lo    = (4,15)
+@endif
 ;
 
 define token instr32 (32)
@@ -71,7 +84,11 @@ define token instr32 (32)
 
 attach variables [ ri rj ] [ R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12 AC FP SP ];
 
+@ifndef FR81_EXTENSION
 attach variables [ rs rs4_4 ] [ TBR RP SSP USP MDH MDL _ _ _ _ _ _ _ _ _ _ ];
+@else
+attach variables [ rs rs4_4 ] [ TBR RP SSP USP MDH MDL BP FCR ESR _ _ _ _ _ _ DBR ];
+@endif
 
 # ====
 

--- a/data/languages/fr60.sinc
+++ b/data/languages/fr60.sinc
@@ -75,6 +75,7 @@ define token instr (16)
     o14shi   = (0,2) signed
     o14uhi   = (0,2) signed
     o14lo    = (4,15)
+    u16      = (0,15)
 @endif
 ;
 

--- a/data/languages/fr60.sinc
+++ b/data/languages/fr60.sinc
@@ -22,6 +22,9 @@ define token instr (16)
     s8       = (0,7) signed
     rel8     = (0,7) signed
     dir8     = (0,7)
+    rel20hi  = (0,3) signed
+    rel20lo  = (0,15)
+
     stmrlist7 = (0,0)
     stmrlist6 = (1,1)
     stmrlist5 = (2,2)
@@ -1164,6 +1167,8 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export tmp; }
 
 # ====
 
+@ifndef FR81_EXTENSION
+
 # COPOP #u4, #u8, CRj, CRi E 9F-C 2+a ---- Operation instruction
 :COPOP #ccu4, #copcc, crj, cri is op12=0x9fc & ccu4 ; copcc & crj & cri {
     local tmp0:4 = ccu4;
@@ -1196,6 +1201,8 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export tmp; }
     local tmp2:4 = crj;
     ri = copsv(tmp0, tmp1, tmp2, ri);
 }
+
+@endif # FR81_EXTENSION
 
 # ====
 

--- a/data/languages/fr60.sinc
+++ b/data/languages/fr60.sinc
@@ -1346,29 +1346,3 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export tmp; }
     *:1 rj = temp;
 }
 
-# ===
-# SRCH0 Ri E 97-C ---- search_zero(Ri) → Ri
-:SRCH0 ri is op12=0x97c & ri {
-    local tmp:4 = ~ri;
-    ri = 32;
-    if (tmp == 0) goto inst_next;
-    ri = clz(tmp);
-}
-
-# SRCH1 Ri E 97-D ---- search_one(Ri) → Ri
-:SRCH1 ri is op12=0x97d & ri {
-    local tmp:4 = ri;
-    ri = 32;
-    if (tmp == 0) goto inst_next;
-    ri = clz(tmp);
-}
-
-# SRCHC Ri E 97-E ---- search_change(Ri) → Ri
-:SRCHC ri is op12=0x97e & ri {
-    local tmp:4 = ri;
-    local neg = tmp s< 0;
-    tmp = (tmp * zext(neg == 0)) + (~tmp * zext(neg != 0));
-    ri = 32;
-    if (tmp == 0) goto inst_next;
-    ri = clz(tmp);
-}

--- a/data/languages/fr60.sinc
+++ b/data/languages/fr60.sinc
@@ -1065,6 +1065,16 @@ CC: "HI" is cc=0xF { local tmp:1 = ((C | Z) == 0); export tmp; }
     if (CC != 0) goto REL;
 }
 
+# special case to improve decompiled code
+:BRA REL is op4=0xE & cc=0 & REL {
+	goto REL;
+}
+:BRA^":D" REL is op4=0xF & cc=0 & REL {
+    delayslot(1);
+    goto REL;
+}
+
+
 # ====
 
 # DMOV @dir10, R13 D 08 b ---- (dir10) --> R13

--- a/data/languages/fr81.slaspec
+++ b/data/languages/fr81.slaspec
@@ -17,9 +17,6 @@ define register offset=0x80 size=4 [ FR0 FR1 FR2 FR3 FR4 FR5 FR6 FR7 FR8 FR9 FR1
 # these registers are used and then synced when there is PS access
 define register offset=0x100 size=1 [ ILM D1 D0 T S I N Z V C ];
 
-# and same for floating point (FCR register)
-define register offset=0x120 size=1 [ FCR_E FCR_L FCR_G FCR_U ];
-
 
 @define FR81_EXTENSION
 

--- a/data/languages/fr81.slaspec
+++ b/data/languages/fr81.slaspec
@@ -5,15 +5,20 @@ define space register type=register_space size=4;
 
 define space ram type=ram_space size=4 wordsize=1 default;
 
-define register offset=0x00 size=4 [ PC RP SSP USP MDH MDL PS TBR ];           #R13 #R14 #R15
-define register offset=0x00 size=8 [ _     _       MD      _      ];
-define register offset=0x20 size=4 [ R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12  _    _    _  ];
-define register offset=0x20 size=4 [ _  _  _  _  _  _  _  _  _  _  _   _   _    AC   FP   SP ];
+define register offset=0x00 size=4 [ PC RP SSP USP MDH MDL PS TBR BP FCR ESR DBR];
+define register offset=0x00 size=8 [ _     _       MD      ];
+define register offset=0x40 size=4 [ R0 R1 R2 R3 R4 R5 R6 R7 R8 R9 R10 R11 R12  _    _    _  ];
+define register offset=0x40 size=4 [ _  _  _  _  _  _  _  _  _  _  _   _   _    AC   FP   SP ];
+
+define register offset=0x80 size=4 [ FR0 FR1 FR2 FR3 FR4 FR5 FR6 FR7 FR8 FR9 FR10 FR11 FR12 FR13 FR14 FR15 ];
 
 # Fake flag registers for cleaner p-code decomp
 # Instead of reading/writing bits to PS directly in each instruction
 # these registers are used and then synced when there is PS access
-define register offset=0x80 size=1 [ ILM D1 D0 T S I N Z V C ];
+define register offset=0x100 size=1 [ ILM D1 D0 T S I N Z V C ];
+
+# and same for floating point (FCR register)
+define register offset=0x120 size=1 [ FCR_E FCR_L FCR_G FCR_U ];
 
 
 @define FR81_EXTENSION

--- a/data/languages/fr81.slaspec
+++ b/data/languages/fr81.slaspec
@@ -15,4 +15,8 @@ define register offset=0x20 size=4 [ _  _  _  _  _  _  _  _  _  _  _   _   _    
 # these registers are used and then synced when there is PS access
 define register offset=0x80 size=1 [ ILM D1 D0 T S I N Z V C ];
 
+
+@define FR81_EXTENSION
+
 @include "fr60.sinc"
+@include "fr81ext.sinc"

--- a/data/languages/fr81ext.sinc
+++ b/data/languages/fr81ext.sinc
@@ -6,6 +6,13 @@
 
 attach variables [ fri frj frk ] [ FR0 FR1 FR2 FR3 FR4 FR5 FR6 FR7 FR8 FR9 FR10 FR11 FR12 FR13 FR14 FR15 ];
 
+# Floating point condition code flags
+@define FCR_E "FCR[31,1]"	# equal
+@define FCR_L "FCR[30,1]"	# less than
+@define FCR_G "FCR[29,1]"	# greater than
+@define FCR_U "FCR[28,1]"	# unordered - cannot compare
+
+
 
 define pcodeop TODO;
 
@@ -109,11 +116,11 @@ Label21: addr is rel20hi ; rel20lo
 
 # FCMPs FRk, FRj, FRi (7.67)
 :FCMPs frk, frj is op16=0x07A4 ; frj & frk {
-	FCR_E = frk f== frj;
-	FCR_L = frk f< frj;
-	FCR_G = frk f> frj;
-	FCR_U = 0; # not possible to compare
-	# TODO pack bits into single reg
+	local e:4 = zext(frk f== frj) << 31;
+	local l:4 = zext(frk f< frj) << 30;
+	local g:4 = zext(frk f> frj) << 29;
+	local u:4 = zext(nan(frk) || nan(frj)) << 28;
+	FCR = (FCR & 0x0fffffff) | e | l | g | u;
 }
 
 # FMADDs FRk, FRj, FRi (7.77)
@@ -210,20 +217,20 @@ Label21: addr is rel20hi ; rel20lo
 }
 
 FCC: "N"	is fcc=0x0 { local tmp:1 = 0; export tmp; }
-FCC: "U"	is fcc=0x1 { local tmp:1 = FCR_U != 0; export tmp; }
-FCC: "G"	is fcc=0x2 { local tmp:1 = FCR_G != 0; export tmp; }
-FCC: "UG"	is fcc=0x3 { local tmp:1 = (FCR_U | FCR_G) != 0; export tmp; }
-FCC: "L"	is fcc=0x4 { local tmp:1 = FCR_L != 0; export tmp; }
-FCC: "UL"	is fcc=0x5 { local tmp:1 = (FCR_U | FCR_L) != 0; export tmp; }
-FCC: "LG"	is fcc=0x6 { local tmp:1 = (FCR_L | FCR_G) != 0; export tmp; }
-FCC: "NE"	is fcc=0x7 { local tmp:1 = (FCR_L | FCR_G | FCR_U) != 0; export tmp; }
-FCC: "E"	is fcc=0x8 { local tmp:1 = FCR_E != 0; export tmp; }
-FCC: "UE"	is fcc=0x9 { local tmp:1 = (FCR_E | FCR_U) != 0; export tmp; }
-FCC: "GE"	is fcc=0xA { local tmp:1 = (FCR_G | FCR_E) != 0; export tmp; }
-FCC: "UGE"	is fcc=0xB { local tmp:1 = (FCR_U | FCR_G | FCR_E) != 0; export tmp; }
-FCC: "LE"	is fcc=0xC { local tmp:1 = (FCR_L | FCR_E) != 0; export tmp; }
-FCC: "ULE" 	is fcc=0xD { local tmp:1 = (FCR_E | FCR_L | FCR_U) != 0; export tmp; }
-FCC: "O"	is fcc=0xE { local tmp:1 = (FCR_E | FCR_L | FCR_G) != 0; export tmp; }
+FCC: "U"	is fcc=0x1 { local tmp:1 = $(FCR_U) != 0; export tmp; }
+FCC: "G"	is fcc=0x2 { local tmp:1 = $(FCR_G) != 0; export tmp; }
+FCC: "UG"	is fcc=0x3 { local tmp:1 = ($(FCR_U) | $(FCR_G)) != 0; export tmp; }
+FCC: "L"	is fcc=0x4 { local tmp:1 = $(FCR_L) != 0; export tmp; }
+FCC: "UL"	is fcc=0x5 { local tmp:1 = ($(FCR_U) | $(FCR_L)) != 0; export tmp; }
+FCC: "LG"	is fcc=0x6 { local tmp:1 = ($(FCR_L) | $(FCR_G)) != 0; export tmp; }
+FCC: "NE"	is fcc=0x7 { local tmp:1 = ($(FCR_L) | $(FCR_G) | $(FCR_U)) != 0; export tmp; }
+FCC: "E"	is fcc=0x8 { local tmp:1 = $(FCR_E) != 0; export tmp; }
+FCC: "UE"	is fcc=0x9 { local tmp:1 = ($(FCR_E) | $(FCR_U)) != 0; export tmp; }
+FCC: "GE"	is fcc=0xA { local tmp:1 = ($(FCR_G) | $(FCR_E)) != 0; export tmp; }
+FCC: "UGE"	is fcc=0xB { local tmp:1 = ($(FCR_U) | $(FCR_G) | $(FCR_E)) != 0; export tmp; }
+FCC: "LE"	is fcc=0xC { local tmp:1 = ($(FCR_L) | $(FCR_E)) != 0; export tmp; }
+FCC: "ULE" 	is fcc=0xD { local tmp:1 = ($(FCR_E) | $(FCR_L) | $(FCR_U)) != 0; export tmp; }
+FCC: "O"	is fcc=0xE { local tmp:1 = ($(FCR_E) | $(FCR_L) | $(FCR_G)) != 0; export tmp; }
 FCC: "A"	is fcc=0xF { local tmp:1 = 1; export tmp; }
 
 Label17: addr is i16 [ addr = inst_next + (i16 * 2); ] { export *:1 addr; }

--- a/data/languages/fr81ext.sinc
+++ b/data/languages/fr81ext.sinc
@@ -1,33 +1,38 @@
 
+# Additional instructions according to
+# "FR81 32-bit microcontroller PROGRAMMING MANUAL"
+# document number CM71-00105-1E (490 pages)
 
-# TODO add float-point registers
+
+attach variables [ fri frj frk ] [ FR0 FR1 FR2 FR3 FR4 FR5 FR6 FR7 FR8 FR9 FR10 FR11 FR12 FR13 FR14 FR15 ];
+
 
 define pcodeop TODO;
 
-label21: lbl is rel20hi ; rel20lo 
-[ lbl = ((rel20hi << 17) | (rel20lo << 1)) + inst_next; ] {
-	export *:4 lbl; 
+Label21: addr is rel20hi ; rel20lo
+[ addr = ((rel20hi << 17) | (rel20lo << 1)) + inst_next; ] {
+	export *:4 addr; 
 }
-# LCALL label21
-:LCALL label21 is op12=0x072... & label21 {
+# LCALL Label21
+:LCALL Label21 is op12=0x072... & Label21 {
 	RP = inst_next;
-	call label21;
+	call Label21;
 }
 # LCALL:D label21
-:LCALL^":D" label21 is op12=0x172... & label21 {
+:LCALL^":D" Label21 is op12=0x172... & Label21 {
     delayslot(1);
 	RP = inst_next + 2;
-	call label21;
+	call Label21;
 }
 
 
 # MOV Rj, FRi
-:MOV rj, ri is op12=0x073 & rj & ri {
-	TODO();
+:MOV ri, fri is op12=0x073 & ri ; fri {
+	fri = ri;
 }
 # MOV FRj, Ri
-:MOV rj, ri is op12=0x173 & rj & ri {
-	TODO();
+:MOV fri, ri is op12=0x173 & ri ; fri {
+	ri = fri;
 }
 
 # LD @(BP, udisp18), Ri
@@ -84,10 +89,140 @@ label21: lbl is rel20hi ; rel20lo
 	TODO();
 }
 
+# FADDs FRk, FRj, FRi
+:FADDs frk, frj, fri is op16=0x07A0 ; fri & frj & frk {
+	TODO();
+}
 
-# LD @R15+, Rs E 07-8 b ---- (R15) --> Rs, R15+=4
-#:LD @SP+, rs is op12=0x078 & rs & SP {
-#    rs = *:4 SP;
-#    SP = SP + 4;
-#}
+# FSUBs FRk, FRj, FRi
+:FSUBs frk, frj, fri is op16=0x07A2 ; fri & frj & frk {
+	TODO();
+}
+
+# FCMPs FRk, FRj, FRi
+:FCMPs frk, frj is op16=0x07A4 ; frj & frk {
+	TODO();
+}
+
+# FMADDs FRk, FRj, FRi
+:FMADDs frk, frj, fri is op16=0x07A5 ; fri & frj & frk {
+	TODO();
+}
+
+# FMSUBs FRk, FRj, FRi
+:FMSUBs frk, frj, fri is op16=0x07A6 ; fri & frj & frk {
+	TODO();
+}
+
+# FMULs FRk, FRj, FRi
+:FMULs frk, frj, fri is op16=0x07A7 ; fri & frj & frk {
+	TODO();
+}
+
+# FiTOs FRj, FRi
+:FMULs frj, fri is op16=0x07A8 ; fri & frj {
+	TODO();
+}
+
+# FsTOi FRj, FRi
+:FMULs frj, fri is op16=0x07A9 ; fri & frj {
+	TODO();
+}
+
+# FDIVs FRk, FRj, FRi
+:FDIVs frk, frj, fri is op16=0x07AA ; fri & frj & frk {
+	TODO();
+}
+
+# FSQRTs FRj, FRi
+:FSQRTs frj, fri is op16=0x07AB ; fri & frj {
+	TODO();
+}
+
+# FABSs FRj, FRi
+:FABSs frj, fri is op16=0x07AC ; fri & frj {
+	TODO();
+}
+
+# FMOVs FRj, FRi (7.78)
+:FMOVs frj, fri is op16=0x07AE ; fri & frj {
+	fri = frj;
+}
+
+# FNEGs FRj, FRi (7.81)
+:FNEGs frj, fri is op16=0x07AF ; fri & frj {
+	fri = 0 f- frj;
+}
+
+
+# FLD @(R14, disp16), FRi (7.72)
+:FLD @(FP, disp16), fri is op14=(0x07D0>>2) & o14shi ; o14lo & fri & FP
+[ disp16 = ((o14shi << 12) | o14lo) * 4; ] {
+	fri = *:4 (FP + disp16);
+}
+# FST FRi, @(R14, disp16) (7.xx)
+:FST fri, @(FP, disp16) is op14=(0x17D0>>2) & o14shi ; o14lo & fri & FP
+[ disp16 = ((o14shi << 12) | o14lo) * 4; ] {
+	TODO();
+}
+
+# FLD @(R15, udisp16), FRi (7.73)
+:FLD @(SP, udisp16), fri is op14=(0x07D4>>2) & o14uhi ; o14lo & fri & SP
+[ udisp16 = ((o14uhi << 12) | o14lo) * 4; ] {
+	fri = *:4 (SP + udisp16);
+}
+# FST FRi, @(R15, udisp16) (7.xx)
+:FST fri, @(SP, udisp16) is op14=(0x17D4>>2) & o14uhi ; o14lo & fri & SP
+[ udisp16 = ((o14uhi << 12) | o14lo) * 4; ] {
+	TODO();
+}
+
+# FLD @R15+, FRi (7.74)
+:FLD @SP+, fri is op14=(0x07D8>>2) ; fri & SP {
+	fri = *:4 SP;
+	SP = SP + 4;
+}
+# FST FRi, @-R15 (7.xx)
+:FST fri, @-SP is op14=(0x17D8>>2) ; fri & SP {
+	SP = SP - 4;
+	*:4 SP = fri;
+}
+
+# FLDM (frlist) (7.76)
+:FLDM "(frlist)" is op14=(0x07DC>>2) ; stmrlist7 {
+	TODO();
+}
+# FSTM (frlist) (7.xx)
+:FSTM "(frlist)" is op14=(0x17DC>>2) ; stmrlist7 {
+	TODO();
+}
+
+FCC: "N"	is fcc=0x0 { local tmp:1 = 0; export tmp; }
+FCC: "U"	is fcc=0x1 { local tmp:1 = FCR_U != 0; export tmp; }
+FCC: "G"	is fcc=0x2 { local tmp:1 = FCR_G != 0; export tmp; }
+FCC: "UG"	is fcc=0x3 { local tmp:1 = (FCR_U | FCR_G) != 0; export tmp; }
+FCC: "L"	is fcc=0x4 { local tmp:1 = FCR_L != 0; export tmp; }
+FCC: "UL"	is fcc=0x5 { local tmp:1 = (FCR_U | FCR_L) != 0; export tmp; }
+FCC: "LG"	is fcc=0x6 { local tmp:1 = (FCR_L | FCR_G) != 0; export tmp; }
+FCC: "NE"	is fcc=0x7 { local tmp:1 = (FCR_L | FCR_G | FCR_U) != 0; export tmp; }
+FCC: "E"	is fcc=0x8 { local tmp:1 = FCR_E != 0; export tmp; }
+FCC: "UE"	is fcc=0x9 { local tmp:1 = (FCR_E | FCR_U) != 0; export tmp; }
+FCC: "GE"	is fcc=0xA { local tmp:1 = (FCR_G | FCR_E) != 0; export tmp; }
+FCC: "UGE"	is fcc=0xB { local tmp:1 = (FCR_U | FCR_G | FCR_E) != 0; export tmp; }
+FCC: "LE"	is fcc=0xC { local tmp:1 = (FCR_L | FCR_E) != 0; export tmp; }
+FCC: "ULE" 	is fcc=0xD { local tmp:1 = (FCR_E | FCR_L | FCR_U) != 0; export tmp; }
+FCC: "O"	is fcc=0xE { local tmp:1 = (FCR_E | FCR_L | FCR_G) != 0; export tmp; }
+FCC: "A"	is fcc=0xF { local tmp:1 = 1; export tmp; }
+
+Label17: addr is i16 [ addr = inst_next + (i16 * 2); ] { export *:1 addr; }
+
+# FBcc label17 (7.65)
+:FB^FCC Label17 is op12=0x07F & FCC ; Label17 {
+    if (FCC) goto Label17;
+}
+# FBcc:D label17 (7.66)
+:FB^FCC^":D" Label17 is op12=0x17F & FCC ; Label17 {
+    delayslot(1);
+    if (FCC) goto Label17;
+}
 

--- a/data/languages/fr81ext.sinc
+++ b/data/languages/fr81ext.sinc
@@ -407,3 +407,29 @@ Label17: addr is i16 [ addr = inst_next + (i16 * 2); ] { export *:1 addr; }
     if (FCC) goto Label17;
 }
 
+
+# SRCH0 Ri E 97-C ---- search_zero(Ri) --> Ri
+:SRCH0 ri is op12=0x97c & ri {
+    local tmp:4 = ~ri;
+    ri = 32;
+    if (tmp == 0) goto inst_next;
+    ri = clz(tmp);
+}
+
+# SRCH1 Ri E 97-D ---- search_one(Ri) --> Ri
+:SRCH1 ri is op12=0x97d & ri {
+    local tmp:4 = ri;
+    ri = 32;
+    if (tmp == 0) goto inst_next;
+    ri = clz(tmp);
+}
+
+# SRCHC Ri E 97-E ---- search_change(Ri) --> Ri
+:SRCHC ri is op12=0x97e & ri {
+    local tmp:4 = ri;
+    local neg = tmp s< 0;
+    tmp = (tmp * zext(neg == 0)) + (~tmp * zext(neg != 0));
+    ri = 32;
+    if (tmp == 0) goto inst_next;
+    ri = clz(tmp);
+}

--- a/data/languages/fr81ext.sinc
+++ b/data/languages/fr81ext.sinc
@@ -12,9 +12,42 @@ attach variables [ fri frj frk ] [ FR0 FR1 FR2 FR3 FR4 FR5 FR6 FR7 FR8 FR9 FR10 
 @define FCR_G "FCR[29,1]"	# greater than
 @define FCR_U "FCR[28,1]"	# unordered - cannot compare
 
+define token fldm_fstm_list(16)
+    fldm0  = (0,0)
+    fldm1  = (1,1)
+    fldm2  = (2,2)
+    fldm3  = (3,3)
+    fldm4  = (4,4)
+    fldm5  = (5,5)
+    fldm6  = (6,6)
+    fldm7  = (7,7)
+    fldm8  = (8,8)
+    fldm9  = (9,9)
+    fldm10 = (10,10)
+    fldm11 = (11,11)
+    fldm12 = (12,12)
+    fldm13 = (13,13)
+    fldm14 = (14,14)
+    fldm15 = (15,15)
 
+    fstm15 = (0,0)
+    fstm14 = (1,1)
+    fstm13 = (2,2)
+    fstm12 = (3,3)
+    fstm11 = (4,4)
+    fstm10 = (5,5)
+    fstm9  = (6,6)
+    fstm8  = (7,7)
+    fstm7  = (8,8)
+    fstm6  = (9,9)
+    fstm5  = (10,10)
+    fstm4  = (11,11)
+    fstm3  = (12,12)
+    fstm2  = (13,13)
+    fstm1  = (14,14)
+    fstm0  = (15,15)
+;
 
-define pcodeop TODO;
 
 Label21: addr is rel20hi ; rel20lo
 [ addr = ((rel20hi << 17) | (rel20lo << 1)) + inst_next; ] {
@@ -208,12 +241,141 @@ Label21: addr is rel20hi ; rel20lo
 }
 
 # FLDM (frlist) (7.76)
-:FLDM "(frlist)" is op14=(0x07DC>>2) ; stmrlist7 {
-	TODO();
+fldm_fr15:	FR15			is FR15 & fldm15=1							{ FR15 = *:4 SP; SP = SP + 4; }
+fldm_fr15:	""				is 		  fldm15=0							{ }
+
+fldm_fr14:	FR14			is FR14 & fldm_fr15 & fldm14=1 & fldm15=0	{ FR14 = *:4 SP; SP = SP + 4;	build fldm_fr15; }
+fldm_fr14:	FR14,fldm_fr15	is FR14 & fldm_fr15 & fldm14=1 & fldm15=1	{ FR14 = *:4 SP; SP = SP + 4;	build fldm_fr15; }
+fldm_fr14:	     fldm_fr15	is 		  fldm_fr15 & fldm14=0				{ build fldm_fr15; }
+
+fldm_fr13:	FR13			is FR13 & fldm_fr14 & fldm13=1 & fldm14=0	{ FR13 = *:4 SP; SP = SP + 4;	build fldm_fr14; }
+fldm_fr13:	FR13,fldm_fr14	is FR13 & fldm_fr14 & fldm13=1 & fldm14=1	{ FR13 = *:4 SP; SP = SP + 4;	build fldm_fr14; }
+fldm_fr13:	     fldm_fr14	is 		  fldm_fr14 & fldm13=0				{ 								build fldm_fr14; }
+
+fldm_fr12:	FR12			is FR12 & fldm_fr13 & fldm12=1 & fldm13=0	{ FR12 = *:4 SP; SP = SP + 4;	build fldm_fr13; }
+fldm_fr12:	FR12,fldm_fr13	is FR12 & fldm_fr13 & fldm12=1 & fldm13=1	{ FR12 = *:4 SP; SP = SP + 4;	build fldm_fr13; }
+fldm_fr12:	     fldm_fr13	is 		  fldm_fr13 & fldm12=0				{ 								build fldm_fr13; }
+
+fldm_fr11:	FR11			is FR11 & fldm_fr12 & fldm11=1 & fldm12=0	{ FR11 = *:4 SP; SP = SP + 4;	build fldm_fr12; }
+fldm_fr11:	FR11,fldm_fr12	is FR11 & fldm_fr12 & fldm11=1 & fldm12=1	{ FR11 = *:4 SP; SP = SP + 4;	build fldm_fr12; }
+fldm_fr11:	     fldm_fr12	is 		  fldm_fr12 & fldm11=0				{ 								build fldm_fr12; }
+
+fldm_fr10:	FR10			is FR10 & fldm_fr11 & fldm10=1 & fldm11=0	{ FR10 = *:4 SP; SP = SP + 4;	build fldm_fr11; }
+fldm_fr10:	FR10,fldm_fr11	is FR10 & fldm_fr11 & fldm10=1 & fldm11=1	{ FR10 = *:4 SP; SP = SP + 4;	build fldm_fr11; }
+fldm_fr10:	     fldm_fr11	is 		  fldm_fr11 & fldm10=0				{ 								build fldm_fr11; }
+
+fldm_fr9:	FR9				is FR9  & fldm_fr10 & fldm9=1 & fldm10=0	{ FR9 = *:4 SP; SP = SP + 4;	build fldm_fr10; }
+fldm_fr9:	FR9,fldm_fr10	is FR9  & fldm_fr10 & fldm9=1 & fldm10=1	{ FR9 = *:4 SP; SP = SP + 4;	build fldm_fr10; }
+fldm_fr9:	    fldm_fr10	is 		  fldm_fr10 & fldm9=0				{ 								build fldm_fr10; }
+
+fldm_fr8:	FR8				is FR8  & fldm_fr9 & fldm8=1 & fldm9=0		{ FR8 = *:4 SP; SP = SP + 4;	build fldm_fr9; }
+fldm_fr8:	FR8,fldm_fr9	is FR8  & fldm_fr9 & fldm8=1 & fldm9=1		{ FR8 = *:4 SP; SP = SP + 4;	build fldm_fr9; }
+fldm_fr8:	    fldm_fr9	is 		  fldm_fr9 & fldm8=0				{ 								build fldm_fr9; }
+
+fldm_fr7:	FR7				is FR7  & fldm_fr8 & fldm7=1 & fldm8=0		{ FR7 = *:4 SP; SP = SP + 4;	build fldm_fr8; }
+fldm_fr7:	FR7,fldm_fr8	is FR7  & fldm_fr8 & fldm7=1 & fldm8=1		{ FR7 = *:4 SP; SP = SP + 4;	build fldm_fr8; }
+fldm_fr7:	    fldm_fr8	is 		  fldm_fr8 & fldm7=0				{ 								build fldm_fr8; }
+
+fldm_fr6:	FR6				is FR6  & fldm_fr7 & fldm6=1 & fldm7=0		{ FR6 = *:4 SP; SP = SP + 4;	build fldm_fr7; }
+fldm_fr6:	FR6,fldm_fr7	is FR6  & fldm_fr7 & fldm6=1 & fldm7=1		{ FR6 = *:4 SP; SP = SP + 4;	build fldm_fr7; }
+fldm_fr6:	    fldm_fr7	is 		  fldm_fr7 & fldm6=0				{ 								build fldm_fr7; }
+
+fldm_fr5:	FR5				is FR5  & fldm_fr6 & fldm5=1 & fldm6=0		{ FR5 = *:4 SP; SP = SP + 4;	build fldm_fr6; }
+fldm_fr5:	FR5,fldm_fr6	is FR5  & fldm_fr6 & fldm5=1 & fldm6=1		{ FR5 = *:4 SP; SP = SP + 4;	build fldm_fr6; }
+fldm_fr5:	    fldm_fr6	is 		  fldm_fr6 & fldm5=0				{ 								build fldm_fr6; }
+
+fldm_fr4:	FR4				is FR4  & fldm_fr5 & fldm6=1 & fldm5=0		{ FR4 = *:4 SP; SP = SP + 4;	build fldm_fr5; }
+fldm_fr4:	FR4,fldm_fr5	is FR4  & fldm_fr5 & fldm6=1 & fldm5=1		{ FR4 = *:4 SP; SP = SP + 4;	build fldm_fr5; }
+fldm_fr4:	    fldm_fr5	is 		  fldm_fr5 & fldm6=0				{ 								build fldm_fr5; }
+
+fldm_fr3:	FR3				is FR3  & fldm_fr4 & fldm5=1 & fldm4=0		{ FR3 = *:4 SP; SP = SP + 4;	build fldm_fr4; }
+fldm_fr3:	FR3,fldm_fr4	is FR3  & fldm_fr4 & fldm5=1 & fldm4=1		{ FR3 = *:4 SP; SP = SP + 4;	build fldm_fr4; }
+fldm_fr3:	    fldm_fr4	is 		  fldm_fr4 & fldm5=0				{ 								build fldm_fr4; }
+
+fldm_fr2:	FR2				is FR2  & fldm_fr3 & fldm4=1 & fldm3=0		{ FR2 = *:4 SP; SP = SP + 4;	build fldm_fr3; }
+fldm_fr2:	FR2,fldm_fr3	is FR2  & fldm_fr3 & fldm4=1 & fldm3=1		{ FR2 = *:4 SP; SP = SP + 4;	build fldm_fr3; }
+fldm_fr2:	    fldm_fr3	is 		  fldm_fr3 & fldm4=0				{ 								build fldm_fr3; }
+
+fldm_fr1:	FR1				is FR1  & fldm_fr2 & fldm3=1 & fldm2=0		{ FR1 = *:4 SP; SP = SP + 4;	build fldm_fr2; }
+fldm_fr1:	FR1,fldm_fr2	is FR1  & fldm_fr2 & fldm3=1 & fldm2=1		{ FR1 = *:4 SP; SP = SP + 4;	build fldm_fr2; }
+fldm_fr1:	    fldm_fr2	is 		  fldm_fr2 & fldm3=0				{ 								build fldm_fr2; }
+
+fldm_fr0:	FR0				is FR0  & fldm_fr1 & fldm2=1 & fldm1=0		{ FR0 = *:4 SP; SP = SP + 4;	build fldm_fr1; }
+fldm_fr0:	FR0,fldm_fr1	is FR0  & fldm_fr1 & fldm2=1 & fldm1=1		{ FR0 = *:4 SP; SP = SP + 4;	build fldm_fr1; }
+fldm_fr0:	    fldm_fr1	is 		  fldm_fr1 & fldm2=0				{ 								build fldm_fr1; }
+
+:FLDM (fldm_fr0) is op14=(0x07DC>>2) ; fldm_fr0 {
+    build fldm_fr0;
 }
+
+
 # FSTM (frlist) (7.89)
-:FSTM "(frlist)" is op14=(0x17DC>>2) ; stmrlist7 {
-	TODO();
+
+fstm_fr15:	FR15			is FR15 & fstm15=1							{ *:4 SP = FR15; SP = SP - 4; }
+fstm_fr15:	""				is 		  fstm15=0							{ }
+
+fstm_fr14:	FR14			is FR14 & fstm_fr15 & fstm14=1 & fstm15=0	{ build fstm_fr15; *:4 SP = FR14; SP = SP - 4; }
+fstm_fr14:	FR14,fstm_fr15	is FR14 & fstm_fr15 & fstm14=1 & fstm15=1	{ build fstm_fr15; *:4 SP = FR14; SP = SP - 4; }
+fstm_fr14:	     fstm_fr15	is 		  fstm_fr15 & fstm14=0				{ build fstm_fr15; }
+
+fstm_fr13:	FR13			is FR13 & fstm_fr14 & fstm13=1 & fstm14=0	{ build fstm_fr14; *:4 SP = FR13; SP = SP - 4; }
+fstm_fr13:	FR13,fstm_fr14	is FR13 & fstm_fr14 & fstm13=1 & fstm14=1	{ build fstm_fr14; *:4 SP = FR13; SP = SP - 4; }
+fstm_fr13:	     fstm_fr14	is 		  fstm_fr14 & fstm13=0				{ build fstm_fr14; }
+
+fstm_fr12:	FR12			is FR12 & fstm_fr13 & fstm12=1 & fstm13=0	{ build fstm_fr13; *:4 SP = FR12; SP = SP - 4; }
+fstm_fr12:	FR12,fstm_fr13	is FR12 & fstm_fr13 & fstm12=1 & fstm13=1	{ build fstm_fr13; *:4 SP = FR12; SP = SP - 4; }
+fstm_fr12:	     fstm_fr13	is 		  fstm_fr13 & fstm12=0				{ build fstm_fr13; }
+
+fstm_fr11:	FR11			is FR11 & fstm_fr12 & fstm11=1 & fstm12=0	{ build fstm_fr12; *:4 SP = FR11; SP = SP - 4; }
+fstm_fr11:	FR11,fstm_fr12	is FR11 & fstm_fr12 & fstm11=1 & fstm12=1	{ build fstm_fr12; *:4 SP = FR11; SP = SP - 4; }
+fstm_fr11:	     fstm_fr12	is 		  fstm_fr12 & fstm11=0				{ build fstm_fr12; }
+
+fstm_fr10:	FR10			is FR10 & fstm_fr11 & fstm10=1 & fstm11=0	{ build fstm_fr11; *:4 SP = FR10; SP = SP - 4; }
+fstm_fr10:	FR10,fstm_fr11	is FR10 & fstm_fr11 & fstm10=1 & fstm11=1	{ build fstm_fr11; *:4 SP = FR10; SP = SP - 4; }
+fstm_fr10:	     fstm_fr11	is 		  fstm_fr11 & fstm10=0				{ build fstm_fr11; }
+
+fstm_fr9:	FR9				is FR9 & fstm_fr10 & fstm9=1 & fstm10=0		{ build fstm_fr10; *:4 SP = FR9; SP = SP - 4; }
+fstm_fr9:	FR9,fstm_fr10	is FR9 & fstm_fr10 & fstm9=1 & fstm10=1		{ build fstm_fr10; *:4 SP = FR9; SP = SP - 4; }
+fstm_fr9:	    fstm_fr10	is 		 fstm_fr10 & fstm9=0				{ build fstm_fr10; }
+
+fstm_fr8:	FR8				is FR8 & fstm_fr9 & fstm8=1 & fstm9=0		{ build fstm_fr9; *:4 SP = FR8; SP = SP - 4; }
+fstm_fr8:	FR8,fstm_fr9	is FR8 & fstm_fr9 & fstm8=1 & fstm9=1		{ build fstm_fr9; *:4 SP = FR8; SP = SP - 4; }
+fstm_fr8:	    fstm_fr9	is 		 fstm_fr9 & fstm8=0					{ build fstm_fr9; }
+
+fstm_fr7:	FR7				is FR7 & fstm_fr8 & fstm7=1 & fstm8=0		{ build fstm_fr8; *:4 SP = FR7; SP = SP - 4; }
+fstm_fr7:	FR7,fstm_fr8	is FR7 & fstm_fr8 & fstm7=1 & fstm8=1		{ build fstm_fr8; *:4 SP = FR7; SP = SP - 4; }
+fstm_fr7:	    fstm_fr8	is 		 fstm_fr8 & fstm7=0					{ build fstm_fr8; }
+
+fstm_fr6:	FR6				is FR6 & fstm_fr7 & fstm6=1 & fstm7=0		{ build fstm_fr7; *:4 SP = FR6; SP = SP - 4; }
+fstm_fr6:	FR6,fstm_fr7	is FR6 & fstm_fr7 & fstm6=1 & fstm7=1		{ build fstm_fr7; *:4 SP = FR6; SP = SP - 4; }
+fstm_fr6:	    fstm_fr7	is 		 fstm_fr7 & fstm6=0					{ build fstm_fr7; }
+
+fstm_fr5:	FR5				is FR5 & fstm_fr6 & fstm5=1 & fstm6=0		{ build fstm_fr6; *:4 SP = FR5; SP = SP - 4; }
+fstm_fr5:	FR5,fstm_fr6	is FR5 & fstm_fr6 & fstm5=1 & fstm6=1		{ build fstm_fr6; *:4 SP = FR5; SP = SP - 4; }
+fstm_fr5:	    fstm_fr6	is 		 fstm_fr6 & fstm5=0					{ build fstm_fr6; }
+
+fstm_fr4:	FR4				is FR4 & fstm_fr5 & fstm4=1 & fstm5=0		{ build fstm_fr5; *:4 SP = FR4; SP = SP - 4; }
+fstm_fr4:	FR4,fstm_fr5	is FR4 & fstm_fr5 & fstm4=1 & fstm5=1		{ build fstm_fr5; *:4 SP = FR4; SP = SP - 4; }
+fstm_fr4:	    fstm_fr5	is 		 fstm_fr5 & fstm4=0					{ build fstm_fr5; }
+
+fstm_fr3:	FR3				is FR3 & fstm_fr4 & fstm3=1 & fstm4=0		{ build fstm_fr4; *:4 SP = FR3; SP = SP - 4; }
+fstm_fr3:	FR3,fstm_fr4	is FR3 & fstm_fr4 & fstm3=1 & fstm4=1		{ build fstm_fr4; *:4 SP = FR3; SP = SP - 4; }
+fstm_fr3:	    fstm_fr4	is 		 fstm_fr4 & fstm3=0					{ build fstm_fr4; }
+
+fstm_fr2:	FR2				is FR2 & fstm_fr3 & fstm2=1 & fstm3=0		{ build fstm_fr3; *:4 SP = FR2; SP = SP - 4; }
+fstm_fr2:	FR2,fstm_fr3	is FR2 & fstm_fr3 & fstm2=1 & fstm3=1		{ build fstm_fr3; *:4 SP = FR2; SP = SP - 4; }
+fstm_fr2:	    fstm_fr3	is 		 fstm_fr3 & fstm2=0					{ build fstm_fr3; }
+
+fstm_fr1:	FR1				is FR1 & fstm_fr2 & fstm1=1 & fstm2=0		{ build fstm_fr2; *:4 SP = FR1; SP = SP - 4; }
+fstm_fr1:	FR1,fstm_fr2	is FR1 & fstm_fr2 & fstm1=1 & fstm2=1		{ build fstm_fr2; *:4 SP = FR1; SP = SP - 4; }
+fstm_fr1:	    fstm_fr2	is 		 fstm_fr2 & fstm1=0					{ build fstm_fr2; }
+
+fstm_fr0:	FR0				is FR0 & fstm_fr1 & fstm0=1 & fstm1=0		{ build fstm_fr1; *:4 SP = FR0; SP = SP - 4; }
+fstm_fr0:	FR0,fstm_fr1	is FR0 & fstm_fr1 & fstm0=1 & fstm1=1		{ build fstm_fr1; *:4 SP = FR0; SP = SP - 4; }
+fstm_fr0:	    fstm_fr1	is 		 fstm_fr1 & fstm0=0					{ build fstm_fr1; }
+
+:FSTM (fstm_fr0) is op14=(0x17DC>>2) ; fstm_fr0 {
+	build fstm_fr0;
 }
 
 FCC: "N"	is fcc=0x0 { local tmp:1 = 0; export tmp; }

--- a/data/languages/fr81ext.sinc
+++ b/data/languages/fr81ext.sinc
@@ -13,12 +13,12 @@ Label21: addr is rel20hi ; rel20lo
 [ addr = ((rel20hi << 17) | (rel20lo << 1)) + inst_next; ] {
 	export *:4 addr; 
 }
-# LCALL Label21
+# LCALL Label21 (7.96)
 :LCALL Label21 is op12=0x072... & Label21 {
 	RP = inst_next;
 	call Label21;
 }
-# LCALL:D label21
+# LCALL:D label21 (7.97)
 :LCALL^":D" Label21 is op12=0x172... & Label21 {
     delayslot(1);
 	RP = inst_next + 2;
@@ -26,122 +26,134 @@ Label21: addr is rel20hi ; rel20lo
 }
 
 
-# MOV Rj, FRi
+# MOV Rj, FRi (7.131)
 :MOV ri, fri is op12=0x073 & ri ; fri {
 	fri = ri;
 }
-# MOV FRj, Ri
+# MOV FRj, Ri (7.132)
 :MOV fri, ri is op12=0x173 & ri ; fri {
 	ri = fri;
 }
 
-# LD @(BP, udisp18), Ri
-:LD "@(BP, udisp18)", ri is op12=0x074 & ri {
-	TODO();
+# LD @(BP, udisp18), Ri (7.103)
+:LD @(BP, udisp18), ri is op12=0x074 & ri ; u16 & BP
+[ udisp18 = u16 * 4; ] {
+	ri = *:4 (BP + udisp18);
 }
-# ST Ri, @(BP, udisp18)
-:ST ri, "@(BP, udisp18)" is op12=0x174 & ri {
-	TODO();
-}
-
-# LDUH @(BP, udisp17), Ri
-:LDUH "@(BP, udisp17)", ri is op12=0x075 & ri {
-	TODO();
-}
-# STUH Ri, @(BP, udisp17)
-:STUH ri, "@(BP, udisp17)" is op12=0x175 & ri {
-	TODO();
+# ST Ri, @(BP, udisp18) (7.154)
+:ST ri, @(BP, udisp18) is op12=0x174 & ri ; u16 & BP
+[ udisp18 = u16 * 4; ] {
+	*:4 (BP + udisp18) = ri;
 }
 
-# LDUB @(BP, udisp16), Ri
-:LDUB "@(BP, udisp16)", ri is op12=0x076 & ri {
-	TODO();
+# LDUH @(BP, udisp17), Ri (7.118)
+:LDUH @(BP, udisp17), ri is op12=0x075 & ri ; u16 & BP
+[ udisp17 = u16 * 2; ] {
+	ri = zext(*:2 (BP + udisp17));
 }
-# STUB Ri, @(BP, udisp16)
-:STUB ri, "@(BP, udisp16)" is op12=0x176 & ri {
-	TODO();
-}
-
-# FLD @(BP, udisp18), FRi
-:FLD "@(BP, udisp18)", ri is op12=0x077 & ri {
-	TODO();
-}
-# FST FRi, @(BP, udisp18)
-:FST ri, "@(BP, udisp18)" is op12=0x177 & ri {
-	TODO();
+# STH Ri, @(BP, udisp17) (7.164)
+:STH ri, @(BP, udisp17) is op12=0x175 & ri ; u16 & BP
+[ udisp17 = u16 * 2; ] {
+	*:2 (BP + udisp17) = ri:2;
 }
 
-# FLD @Rj, FRi
-:FLD @^rj, ri is op12=0x07C & ri & rj {
-	TODO();
+# LDUB @(BP, udisp16), Ri (7.144)
+:LDUB @(BP, udisp16), ri is op12=0x076 & ri ; u16 & BP
+[ udisp16 = u16 * 1; ] {
+	ri = zext(*:1 (BP + udisp16));
 }
-# FST FRi, @Rj
-:FST ri, @^rj is op12=0x17C & ri & rj {
-	TODO();
-}
-
-# FLD @(R13, Rj), FRi
-:FLD @(rj, AC), ri is op12=0x07E & ri & rj & AC {
-	TODO();
-}
-# FST FRi, @(R13, Rj)
-:FST ri, @(AC, rj) is op12=0x17E & ri & rj & AC {
-	TODO();
+# STUB Ri, @(BP, udisp16) (7.160)
+:STUB ri, @(BP, udisp16) is op12=0x176 & ri ; u16 & BP
+[ udisp16 = u16 * 1; ] {
+	*:1 (BP + udisp16) = ri:1;
 }
 
-# FADDs FRk, FRj, FRi
+# FLD @(BP, udisp18), FRi (7.75)
+:FLD @(BP, udisp18), fri is op12=0x077 & fri ; u16 & BP
+[ udisp18 = u16 * 4; ] {
+	fri = *:4 (BP + udisp18);
+}
+# FST FRi, @(BP, udisp18) (7.88)
+:FST fri, @(BP, udisp18) is op12=0x177 & fri ; u16 & BP
+[ udisp18 = u16 * 4; ] {
+	*:4 (BP + udisp18) = fri;
+}
+
+# FLD @Rj, FRi (7.70)
+:FLD @^ri, fri is op12=0x07C & ri ; fri {
+	fri = *:4 ri;
+}
+# FST FRi, @Rj (7.83)
+:FST fri, @^ri is op12=0x17C & ri ; fri {
+	*:4 ri = fri;
+}
+
+# FLD @(R13, Rj), FRi (7.71)
+:FLD @(ri, AC), fri is op12=0x07E & ri ; fri & AC {
+	fri = *:4 (AC + ri);
+}
+# FST FRi, @(R13, Rj) (7.84)
+:FST fri, @(AC, ri) is op12=0x17E & ri ; fri & AC {
+	*:4 (AC + ri) = fri;
+}
+
+# FADDs FRk, FRj, FRi (7.64)
 :FADDs frk, frj, fri is op16=0x07A0 ; fri & frj & frk {
-	TODO();
+	fri = frk f+ frj;
 }
 
-# FSUBs FRk, FRj, FRi
+# FSUBs FRk, FRj, FRi (7.91)
 :FSUBs frk, frj, fri is op16=0x07A2 ; fri & frj & frk {
-	TODO();
+	fri = frk f- frj;
 }
 
-# FCMPs FRk, FRj, FRi
+# FCMPs FRk, FRj, FRi (7.67)
 :FCMPs frk, frj is op16=0x07A4 ; frj & frk {
-	TODO();
+	FCR_E = frk f== frj;
+	FCR_L = frk f< frj;
+	FCR_G = frk f> frj;
+	FCR_U = 0; # not possible to compare
+	# TODO pack bits into single reg
 }
 
-# FMADDs FRk, FRj, FRi
+# FMADDs FRk, FRj, FRi (7.77)
 :FMADDs frk, frj, fri is op16=0x07A5 ; fri & frj & frk {
-	TODO();
+	fri = frk f* frj f+ fri;
 }
 
-# FMSUBs FRk, FRj, FRi
+# FMSUBs FRk, FRj, FRi (7.79)
 :FMSUBs frk, frj, fri is op16=0x07A6 ; fri & frj & frk {
-	TODO();
+	fri = frk f* frj f- fri;
 }
 
-# FMULs FRk, FRj, FRi
+# FMULs FRk, FRj, FRi (7.80)
 :FMULs frk, frj, fri is op16=0x07A7 ; fri & frj & frk {
-	TODO();
+	fri = frk f* frj;
 }
 
-# FiTOs FRj, FRi
+# FiTOs FRj, FRi (7.69)
 :FMULs frj, fri is op16=0x07A8 ; fri & frj {
-	TODO();
+	fri = int2float(frj);
 }
 
-# FsTOi FRj, FRi
+# FsTOi FRj, FRi (7.90)
 :FMULs frj, fri is op16=0x07A9 ; fri & frj {
-	TODO();
+	fri = round(frj); # not sure how rounding works in this CPU
 }
 
-# FDIVs FRk, FRj, FRi
+# FDIVs FRk, FRj, FRi (7.68)
 :FDIVs frk, frj, fri is op16=0x07AA ; fri & frj & frk {
-	TODO();
+	fri = frk f/ frj;
 }
 
-# FSQRTs FRj, FRi
+# FSQRTs FRj, FRi (7.82)
 :FSQRTs frj, fri is op16=0x07AB ; fri & frj {
-	TODO();
+	fri = sqrt(frj);
 }
 
-# FABSs FRj, FRi
+# FABSs FRj, FRi (7.63)
 :FABSs frj, fri is op16=0x07AC ; fri & frj {
-	TODO();
+	fri = abs(frj);
 }
 
 # FMOVs FRj, FRi (7.78)
@@ -160,10 +172,10 @@ Label21: addr is rel20hi ; rel20lo
 [ disp16 = ((o14shi << 12) | o14lo) * 4; ] {
 	fri = *:4 (FP + disp16);
 }
-# FST FRi, @(R14, disp16) (7.xx)
+# FST FRi, @(R14, disp16) (7.85)
 :FST fri, @(FP, disp16) is op14=(0x17D0>>2) & o14shi ; o14lo & fri & FP
 [ disp16 = ((o14shi << 12) | o14lo) * 4; ] {
-	TODO();
+	*:4 (FP + disp16) = fri;
 }
 
 # FLD @(R15, udisp16), FRi (7.73)
@@ -171,10 +183,10 @@ Label21: addr is rel20hi ; rel20lo
 [ udisp16 = ((o14uhi << 12) | o14lo) * 4; ] {
 	fri = *:4 (SP + udisp16);
 }
-# FST FRi, @(R15, udisp16) (7.xx)
+# FST FRi, @(R15, udisp16) (7.86)
 :FST fri, @(SP, udisp16) is op14=(0x17D4>>2) & o14uhi ; o14lo & fri & SP
 [ udisp16 = ((o14uhi << 12) | o14lo) * 4; ] {
-	TODO();
+	*:4 (SP + udisp16) = fri;
 }
 
 # FLD @R15+, FRi (7.74)
@@ -182,7 +194,7 @@ Label21: addr is rel20hi ; rel20lo
 	fri = *:4 SP;
 	SP = SP + 4;
 }
-# FST FRi, @-R15 (7.xx)
+# FST FRi, @-R15 (7.87)
 :FST fri, @-SP is op14=(0x17D8>>2) ; fri & SP {
 	SP = SP - 4;
 	*:4 SP = fri;
@@ -192,7 +204,7 @@ Label21: addr is rel20hi ; rel20lo
 :FLDM "(frlist)" is op14=(0x07DC>>2) ; stmrlist7 {
 	TODO();
 }
-# FSTM (frlist) (7.xx)
+# FSTM (frlist) (7.89)
 :FSTM "(frlist)" is op14=(0x17DC>>2) ; stmrlist7 {
 	TODO();
 }

--- a/data/languages/fr81ext.sinc
+++ b/data/languages/fr81ext.sinc
@@ -1,0 +1,93 @@
+
+
+# TODO add float-point registers
+
+define pcodeop TODO;
+
+label21: lbl is rel20hi ; rel20lo 
+[ lbl = ((rel20hi << 17) | (rel20lo << 1)) + inst_next; ] {
+	export *:4 lbl; 
+}
+# LCALL label21
+:LCALL label21 is op12=0x072... & label21 {
+	RP = inst_next;
+	call label21;
+}
+# LCALL:D label21
+:LCALL^":D" label21 is op12=0x172... & label21 {
+    delayslot(1);
+	RP = inst_next + 2;
+	call label21;
+}
+
+
+# MOV Rj, FRi
+:MOV rj, ri is op12=0x073 & rj & ri {
+	TODO();
+}
+# MOV FRj, Ri
+:MOV rj, ri is op12=0x173 & rj & ri {
+	TODO();
+}
+
+# LD @(BP, udisp18), Ri
+:LD "@(BP, udisp18)", ri is op12=0x074 & ri {
+	TODO();
+}
+# ST Ri, @(BP, udisp18)
+:ST ri, "@(BP, udisp18)" is op12=0x174 & ri {
+	TODO();
+}
+
+# LDUH @(BP, udisp17), Ri
+:LDUH "@(BP, udisp17)", ri is op12=0x075 & ri {
+	TODO();
+}
+# STUH Ri, @(BP, udisp17)
+:STUH ri, "@(BP, udisp17)" is op12=0x175 & ri {
+	TODO();
+}
+
+# LDUB @(BP, udisp16), Ri
+:LDUB "@(BP, udisp16)", ri is op12=0x076 & ri {
+	TODO();
+}
+# STUB Ri, @(BP, udisp16)
+:STUB ri, "@(BP, udisp16)" is op12=0x176 & ri {
+	TODO();
+}
+
+# FLD @(BP, udisp18), FRi
+:FLD "@(BP, udisp18)", ri is op12=0x077 & ri {
+	TODO();
+}
+# FST FRi, @(BP, udisp18)
+:FST ri, "@(BP, udisp18)" is op12=0x177 & ri {
+	TODO();
+}
+
+# FLD @Rj, FRi
+:FLD @^rj, ri is op12=0x07C & ri & rj {
+	TODO();
+}
+# FST FRi, @Rj
+:FST ri, @^rj is op12=0x17C & ri & rj {
+	TODO();
+}
+
+# FLD @(R13, Rj), FRi
+:FLD @(rj, AC), ri is op12=0x07E & ri & rj & AC {
+	TODO();
+}
+# FST FRi, @(R13, Rj)
+:FST ri, @(AC, rj) is op12=0x17E & ri & rj & AC {
+	TODO();
+}
+
+
+# LD @R15+, Rs E 07-8 b ---- (R15) --> Rs, R15+=4
+#:LD @SP+, rs is op12=0x078 & rs & SP {
+#    rs = *:4 SP;
+#    SP = SP + 4;
+#}
+


### PR DESCRIPTION
I worked with FR-81 binary, and found that this chip is pretty close to the FR-60.
It have exactly the same instructions plus a few additional commands - 'long' call, some relative load-store and full float-point set.

So, here is
- full support for FR-81 (as a separate 'language' in Ghidra terms)
- minor fix for non-conditional branches (original code makes `if (true) goto ...`, that's annoing (both for FR-60 and FR-81)
- calling convention fix, to support byte / short in fuction parameters (also, for both CPUs)
